### PR TITLE
Add libraries and fix typo

### DIFF
--- a/app/views/landing_page.scala.html
+++ b/app/views/landing_page.scala.html
@@ -2,11 +2,11 @@
 @standard_layout() {
     <section class="section-wrapper">
         <h1>About the catalogue</h1>
-        <p>The catalogue is a resource you can use to find information about teams working on the Tax Platform and the
-            services they own.</p>
-        <p>Currently you can browse a list of teams or a list of services (which you can search using your browser) and drill down to access links to Jenkins, Travis
-            &amp; Github for each service belonging to that team.</p>
-        <p>This service is currently in an early alpha phase, and needs your feedback in order to improve. If you have
+        <p>The catalogue is a resource you can use to find information about teams working on the Tax Platform, and the
+            services and libraries they own.</p>
+        <p>You can browse the lists (which are searchable using your browser) and drill down to access links to Jenkins, Travis
+            &amp; Github for each service or library belonging to that team)</p>
+        <p>This service is currently in an alpha phase, and needs your feedback in order to improve. If you have
             anything to offer, or find something wrong, you can contact us in the
             <a href="https://hmrcdigital.slack.com/messages/team-platops/" target="_blank">#team-platops</a>
             room in Slack.</p>
@@ -16,7 +16,7 @@
         <p>We use team and repository information from Github open and Github Enterprise in order to programatically build
             the catalogue. If you notice something is not quite right, you can usually fix it by updating Github directly.<p>
         <p>Currently we only show data for repositories that contain services. We consider a repository as a service if we
-            find either an <em>app</em> folder, or a <em>Procfile</em> in it's root directory.</p>
+            find either an <em>app</em> folder, or a <em>Procfile</em> in its root directory.</p>
         <p>Some teams and repositories are hidden, for example microservice templates that have the structure of play apps
             but are not services themselves. This list is maintained in
             <a href="@Html(ViewMessages.appConfigBaseUrl)">app-config-base</a>. If you want a repository or team hidden,


### PR DESCRIPTION
Libraries weren't in the original release (and possessive "its" has no apostrophe)