### PR TITLE
Search filter tweaks

### DIFF
--- a/app/assets/catalogue-frontend.scss
+++ b/app/assets/catalogue-frontend.scss
@@ -207,3 +207,11 @@ section {
   background-color: transparent;
   outline: none;
 }
+
+.col {
+  padding: 0;
+}
+
+.padding-reset-right {
+  padding-right: 0;
+}

--- a/app/views/repositories_list.scala.html
+++ b/app/views/repositories_list.scala.html
@@ -43,20 +43,16 @@
 
 
 <div id="service-list">
-    <form action="/repositories" method="get" class="form-inline">
-
-        <span>Name: <input type="text" name="name" value=@{form("name").value}></span>
-        <span>Type:
-            <select name="repoType">
-
-                @repoTypes.map{rt =>
-                    <option value="@rt._1" @{if(rt._1 == form("repoType").value.getOrElse("")) "selected"}>@rt._2</option>
-                }
-            </select>
-        </span>
-
-
-        <input type="submit" value="Filter">
+    <form action="/repositories" method="get">
+        <div class="form-group row">
+            <div class="col-xs-1 padding-reset-right">
+                <label for="search">Name:</label>
+            </div>
+            <div class="col col-xs-3">
+                <input class="search form-control" id="search" type="text" name="name"
+                value="@form("name").value" autofocus>
+            </div>
+        </div>
     </form>
 
         <table class="table table-striped">

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -5973,3 +5973,9 @@ section span.other-teams-message {
   border: none;
   background-color: transparent;
   outline: none; }
+
+.col {
+  padding: 0; }
+
+.padding-reset-right {
+  padding-right: 0; }


### PR DESCRIPTION
This PR contains a few tweaks around the search filter. 
IMO a little more work is needed around the functionality of the filter/search. As @eisenhower444 pointed out the `Type:` row could potentially be removed.

- Update Html to be more semantic
- Add `autofocus` to name input
- Add more bootstrap styles
- Remove type row for the moment
- Make filter/search work `onChange`

![filter](https://cloud.githubusercontent.com/assets/2305016/20719210/26f9dc02-b653-11e6-9be7-d88892cf7cf5.gif)
