### PR TITLE
BDOG-33 removed play.ws.ssl.loose.acceptAnyCertificate setting

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -138,7 +138,6 @@ metrics {
 
 
 
-play.ws.ssl.loose.acceptAnyCertificate=true
 play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' 'unsafe-eval' www.google-analytics.com cdnjs.cloudflare.com www.gstatic.com data:"
 
 # Microservice specific config


### PR DESCRIPTION
Also see: 
https://github.com/hmrc/app-config-platapps-labs/pull/9
https://github.com/hmrc/app-config-base/pull/1345