### PR TITLE
BDOG-182 Bobby Explorer

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/BobbyExplorerController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/BobbyExplorerController.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend
+
+import javax.inject.Inject
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.cataloguefrontend.service.BobbyService
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.BobbyExplorerPage
+
+import scala.concurrent.ExecutionContext
+
+class BobbyExplorerController  @Inject()     (mcc        : MessagesControllerComponents,
+                                              page       : BobbyExplorerPage,
+                                              bobbyService: BobbyService
+                                             )(  implicit val ec: ExecutionContext) extends FrontendController(mcc) {
+  def list(): Action[AnyContent] = Action.async { implicit request =>
+    bobbyService.getRules().map(r => Ok(page(r)))
+  }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
@@ -18,12 +18,13 @@ package uk.gov.hmrc.cataloguefrontend.connector
 
 import javax.inject.{Inject, Singleton}
 import play.api.libs.json._
+import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyRuleSet
 import uk.gov.hmrc.cataloguefrontend.service.ConfigService._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ConfigConnector @Inject()(
@@ -50,4 +51,6 @@ class ConfigConnector @Inject()(
 
   def configByKey(service: String)(implicit hc: HeaderCarrier) =
     http.GET[ConfigByKey](s"$serviceConfigsBaseUrl/config-by-key/$service")
+
+  def bobbyRules()(implicit hc: HeaderCarrier): Future[BobbyRuleSet] = http.GET[BobbyRuleSet](s"$serviceConfigsBaseUrl/bobby/rules")
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRule.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRule.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.connector.model
+
+import java.time.LocalDate
+
+import play.api.libs.json.{Json, Reads}
+
+case class BobbyRule(organisation: String, name: String, range: String, reason: String, from: LocalDate) {
+  val groupArtifactName: String = {
+    val wildcard = "*"
+    if (organisation == wildcard && name == wildcard) "*" else s"$organisation.$name"
+  }
+}
+object BobbyRule {
+  implicit val reader: Reads[BobbyRule] = Json.reads[BobbyRule]
+}
+
+case class BobbyRuleSet(libraries: Seq[BobbyRule], plugins: Seq[BobbyRule])
+object BobbyRuleSet {
+  implicit val reader: Reads[BobbyRuleSet] = Json.reads[BobbyRuleSet]
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRule.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRule.scala
@@ -23,7 +23,7 @@ import play.api.libs.json.{Json, Reads}
 case class BobbyRule(organisation: String, name: String, range: String, reason: String, from: LocalDate) {
   val groupArtifactName: String = {
     val wildcard = "*"
-    if (organisation == wildcard && name == wildcard) "*" else s"$organisation.$name"
+    if (organisation == wildcard && name == wildcard) "*" else s"$organisation:$name"
   }
 }
 object BobbyRule {

--- a/app/uk/gov/hmrc/cataloguefrontend/service/BobbyService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/BobbyService.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.service
+
+import java.time.{Clock, LocalDate}
+
+import javax.inject.Inject
+import uk.gov.hmrc.cataloguefrontend.connector.ConfigConnector
+import uk.gov.hmrc.cataloguefrontend.connector.model.{BobbyRule, BobbyRuleSet}
+import uk.gov.hmrc.cataloguefrontend.service.model.BobbyRulesView
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class BobbyService @Inject()(configConnector: ConfigConnector, clock: Clock)(implicit val ec: ExecutionContext) {
+
+  def getRules()(implicit hc: HeaderCarrier) : Future[BobbyRulesView] = {
+    val today = LocalDate.now(clock)
+    def filterUpcoming(rule: BobbyRule) = rule.from.isAfter(today)
+    def filterActive(rule: BobbyRule) = rule.from.isBefore(today) || rule.from.isEqual(today)
+    def compareUpcoming(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2, (date1, date2) => (date1 compareTo date2) < 0)
+    def compareActive(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2, (date1, date2) => (date1 compareTo date2) > 0)
+    def compareRules(x: BobbyRule, y: BobbyRule, compareDates: (LocalDate, LocalDate) => Boolean) = {
+      if (x.from == y.from) (x.groupArtifactName compare y.groupArtifactName) < 0
+      else compareDates(x.from, y.from)
+    }
+    configConnector.bobbyRules().map(r => BobbyRulesView(
+        upcoming = BobbyRuleSet(libraries = r.libraries.filter(filterUpcoming).sortWith(compareUpcoming), plugins = r.plugins.filter(filterUpcoming).sortWith(compareUpcoming)),
+        active = BobbyRuleSet(libraries = r.libraries.filter(filterActive).sortWith(compareActive), plugins = r.plugins.filter(filterActive).sortWith(compareActive)))
+    )
+  }
+
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/service/BobbyService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/BobbyService.scala
@@ -32,11 +32,10 @@ class BobbyService @Inject()(configConnector: ConfigConnector, clock: Clock)(imp
     val today = LocalDate.now(clock)
     def filterUpcoming(rule: BobbyRule) = rule.from.isAfter(today)
     def filterActive(rule: BobbyRule) = rule.from.isBefore(today) || rule.from.isEqual(today)
-    def compareUpcoming(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2)(_ < _)
-    def compareActive(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2)(_ > _)
-    def compareRules(x: BobbyRule, y: BobbyRule)(sortDirection: (Int, Int) => Boolean) =
-      if (x.from == y.from) x.groupArtifactName < y.groupArtifactName
-      else sortDirection(x.from compareTo y.from, 0)
+    def compareUpcoming(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2)(_ isBefore _)
+    def compareActive(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2)(_ isAfter _)
+    def compareRules(x: BobbyRule, y: BobbyRule)(sortDirection: (LocalDate, LocalDate) => Boolean) =
+      if (x.from == y.from) x.groupArtifactName < y.groupArtifactName else sortDirection(x.from, y.from)
 
     configConnector.bobbyRules().map(r => BobbyRulesView(
         upcoming = BobbyRuleSet(libraries = r.libraries.filter(filterUpcoming).sortWith(compareUpcoming), plugins = r.plugins.filter(filterUpcoming).sortWith(compareUpcoming)),

--- a/app/uk/gov/hmrc/cataloguefrontend/service/BobbyService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/BobbyService.scala
@@ -32,12 +32,12 @@ class BobbyService @Inject()(configConnector: ConfigConnector, clock: Clock)(imp
     val today = LocalDate.now(clock)
     def filterUpcoming(rule: BobbyRule) = rule.from.isAfter(today)
     def filterActive(rule: BobbyRule) = rule.from.isBefore(today) || rule.from.isEqual(today)
-    def compareUpcoming(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2, (date1, date2) => (date1 compareTo date2) < 0)
-    def compareActive(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2, (date1, date2) => (date1 compareTo date2) > 0)
-    def compareRules(x: BobbyRule, y: BobbyRule, compareDates: (LocalDate, LocalDate) => Boolean) = {
-      if (x.from == y.from) (x.groupArtifactName compare y.groupArtifactName) < 0
-      else compareDates(x.from, y.from)
-    }
+    def compareUpcoming(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2)(_ < _)
+    def compareActive(rule1: BobbyRule, rule2: BobbyRule) = compareRules(rule1, rule2)(_ > _)
+    def compareRules(x: BobbyRule, y: BobbyRule)(sortDirection: (Int, Int) => Boolean) =
+      if (x.from == y.from) x.groupArtifactName < y.groupArtifactName
+      else sortDirection(x.from compareTo y.from, 0)
+
     configConnector.bobbyRules().map(r => BobbyRulesView(
         upcoming = BobbyRuleSet(libraries = r.libraries.filter(filterUpcoming).sortWith(compareUpcoming), plugins = r.plugins.filter(filterUpcoming).sortWith(compareUpcoming)),
         active = BobbyRuleSet(libraries = r.libraries.filter(filterActive).sortWith(compareActive), plugins = r.plugins.filter(filterActive).sortWith(compareActive)))

--- a/app/uk/gov/hmrc/cataloguefrontend/service/model/BobbyRulesView.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/model/BobbyRulesView.scala
@@ -14,17 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cataloguefrontend
+package uk.gov.hmrc.cataloguefrontend.service.model
 
-import java.time.Clock
+import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyRuleSet
 
-import com.google.inject.AbstractModule
-import uk.gov.hmrc.cataloguefrontend.service.EventsReloadScheduler
-
-class CatalogueFrontendModule extends AbstractModule {
-
-  override def configure(): Unit = {
-    bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
-    bind(classOf[EventsReloadScheduler]).asEagerSingleton()
-  }
-}
+case class BobbyRulesView (upcoming: BobbyRuleSet, active: BobbyRuleSet)

--- a/app/views/BobbyExplorerPage.scala.html
+++ b/app/views/BobbyExplorerPage.scala.html
@@ -41,7 +41,7 @@
 @bobbyRulesArtifactTypeSection(rulesByArtifactType: Seq[BobbyRule], artifactType: String, cssClass: String) = {
     @if(rulesByArtifactType.nonEmpty) {
         <div>
-            <table class="@cssClass">
+            <table class="@{artifactType.toLowerCase}-rules @cssClass">
                 <thead>
                     <tr>
                         <th>@artifactType</th>

--- a/app/views/BobbyExplorerPage.scala.html
+++ b/app/views/BobbyExplorerPage.scala.html
@@ -1,0 +1,68 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.ViewMessages
+@import uk.gov.hmrc.cataloguefrontend.connector.model.{BobbyRule, BobbyRuleSet}
+@import uk.gov.hmrc.cataloguefrontend.service.model.BobbyRulesView
+
+@this(viewMessages: ViewMessages)
+
+@(rules: BobbyRulesView)(implicit request: Request[_])
+
+@standard_layout(s"Bobby rules") {
+    <header>
+        <h1>Bobby Rules</h1>
+    </header>
+    @bobbyRulesTimeSection(rules.upcoming, "Upcoming", "table table-striped")
+    @bobbyRulesTimeSection(rules.active, "Active", "table table-striped-warning")
+}
+
+@bobbyRulesTimeSection(rulesByTime: BobbyRuleSet, heading: String, cssClass: String) = {
+    @if(rulesByTime.libraries.nonEmpty || rulesByTime.plugins.nonEmpty) {
+        <div><h2>@heading</h2></div>
+        @bobbyRulesArtifactTypeSection(rulesByTime.libraries, "Library", cssClass)
+        @bobbyRulesArtifactTypeSection(rulesByTime.plugins, "Plugin", cssClass)
+    }
+}
+
+@bobbyRulesArtifactTypeSection(rulesByArtifactType: Seq[BobbyRule], artifactType: String, cssClass: String) = {
+    @if(rulesByArtifactType.nonEmpty) {
+        <div>
+            <table class="@cssClass">
+                <thead>
+                    <tr>
+                        <th>@artifactType</th>
+                        <th>Version</th>
+                        <th>Reason</th>
+                        <th>Active from</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @rulesByArtifactType.map(bobbyRuleRow)
+                </tbody>
+            </table>
+        </div>
+    }
+}
+
+@bobbyRuleRow(rule: BobbyRule) = {
+    <tr>
+        <td>@rule.groupArtifactName</td>
+        <td>@rule.range</td>
+        <td>@rule.reason</td>
+        <td>@rule.from</td>
+    </tr>
+}

--- a/app/views/BobbyExplorerPage.scala.html
+++ b/app/views/BobbyExplorerPage.scala.html
@@ -57,7 +57,7 @@
         </div>
     }
 }
-
+  
 @bobbyRuleRow(rule: BobbyRule) = {
     <tr class="bobby-rule">
         <td>@rule.groupArtifactName</td>

--- a/app/views/BobbyExplorerPage.scala.html
+++ b/app/views/BobbyExplorerPage.scala.html
@@ -59,7 +59,7 @@
 }
 
 @bobbyRuleRow(rule: BobbyRule) = {
-    <tr>
+    <tr class="bobby-rule">
         <td>@rule.groupArtifactName</td>
         <td>@rule.range</td>
         <td>@rule.reason</td>

--- a/app/views/standard_layout.scala.html
+++ b/app/views/standard_layout.scala.html
@@ -83,6 +83,7 @@
                             Tools<span class="caret"></span>
                         </a>
                         <ul class="dropdown-menu">
+                            <li><a href="@appRoutes.BobbyExplorerController.list">Bobby Explorer</a></li>
                             <li><a href="@appRoutes.DependencyExplorerController.landing">Dependency Explorer</a></li>
                             <li><a href="@appRoutes.JDKVersionController.compareAllEnvironments()">JDK Explorer</a></li>
                             <li><a href="@appRoutes.SearchByUrlController.searchLanding#">Search by URL</a></li>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -41,3 +41,5 @@ GET        /dependencyexplorer/results                  uk.gov.hmrc.cataloguefro
 
 GET        /jdkexplorer/:env                            uk.gov.hmrc.cataloguefrontend.JDKVersionController.findLatestVersions(env: String)
 GET        /jdkexplorer                                 uk.gov.hmrc.cataloguefrontend.JDKVersionController.compareAllEnvironments
+
+GET        /bobbyrules                                  uk.gov.hmrc.cataloguefrontend.BobbyExplorerController.list()

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -7900,6 +7900,9 @@ th {
 .table-striped > tbody > tr:nth-of-type(odd) {
   background-color: #f9f9f9; }
 
+.table-striped-warning > tbody > tr:nth-of-type(odd) {
+  background-color: #ffb6b6; }
+
 .table-hover > tbody > tr:hover {
   background-color: #f5f5f5; }
 

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleFactory.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleFactory.scala
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cataloguefrontend
+package uk.gov.hmrc.cataloguefrontend.connector.model
 
-import java.time.Clock
+import java.time.LocalDate
 
-import com.google.inject.AbstractModule
-import uk.gov.hmrc.cataloguefrontend.service.EventsReloadScheduler
-
-class CatalogueFrontendModule extends AbstractModule {
-
-  override def configure(): Unit = {
-    bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
-    bind(classOf[EventsReloadScheduler]).asEagerSingleton()
-  }
+object BobbyRuleFactory {
+  def aBobbyRule(organisation: String = "uk.gov.hmrc", name: String = "play-frontend", range: String = "[*-SNAPSHOT]", reason: String = "No snapshot dependencies permitted", from: LocalDate = LocalDate.of(2015, 3, 16)) =
+    BobbyRule(organisation, name, range, reason, from)
 }

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleSpec.scala
@@ -14,17 +14,22 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.cataloguefrontend
+package uk.gov.hmrc.cataloguefrontend.connector.model
 
-import java.time.Clock
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyRuleFactory.aBobbyRule
 
-import com.google.inject.AbstractModule
-import uk.gov.hmrc.cataloguefrontend.service.EventsReloadScheduler
+class BobbyRuleSpec extends WordSpec with Matchers {
 
-class CatalogueFrontendModule extends AbstractModule {
+  "groupArtifactName" should {
 
-  override def configure(): Unit = {
-    bind(classOf[Clock]).toInstance(Clock.systemDefaultZone)
-    bind(classOf[EventsReloadScheduler]).asEagerSingleton()
+    "return group ID and artifact ID" in {
+      aBobbyRule(organisation = "a", name = "b").groupArtifactName should be("a.b")
+    }
+
+    "return All for *" in {
+      aBobbyRule(organisation = "*", name = "*").groupArtifactName should be("*")
+    }
+
   }
 }

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleSpec.scala
@@ -24,10 +24,10 @@ class BobbyRuleSpec extends WordSpec with Matchers {
   "groupArtifactName" should {
 
     "return group ID and artifact ID" in {
-      aBobbyRule(organisation = "a", name = "b").groupArtifactName should be("a.b")
+      aBobbyRule(organisation = "a", name = "b").groupArtifactName should be("a:b")
     }
 
-    "return All for *" in {
+    "return * for matching all" in {
       aBobbyRule(organisation = "*", name = "*").groupArtifactName should be("*")
     }
 

--- a/test/uk/gov/hmrc/cataloguefrontend/service/BobbyServiceSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/service/BobbyServiceSpec.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.service
+
+import java.time._
+
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.cataloguefrontend.connector.ConfigConnector
+import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyRuleFactory.aBobbyRule
+import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyRuleSet
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class BobbyServiceSpec extends UnitSpec with MockitoSugar {
+
+  private implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+  private val connector = mock[ConfigConnector]
+  private val today = LocalDate.of(2000, Month.JANUARY, 1)
+  private val now = LocalDateTime.of(today, LocalTime.of(1,1,1))
+  private val fixedClock = Clock.fixed(now.toInstant(ZoneOffset.UTC), ZoneId.systemDefault())
+  private val clock = mock[Clock]
+  when(clock.instant()).thenReturn(fixedClock.instant())
+  when(clock.getZone).thenReturn(fixedClock.getZone)
+  private val service = new BobbyService(connector, clock)
+
+  "getRules" should {
+
+    "split rules into upcoming dependencies if from date is later than today" in {
+
+      val futureLibraryRule = aBobbyRule(name = "future.library", from = today.plusDays(1))
+      val futurePluginRule = aBobbyRule(name = "future.plugin", from = today.plusDays(1))
+      when(connector.bobbyRules()).thenReturn(Future(new BobbyRuleSet(libraries = Seq(futureLibraryRule, aBobbyRule(from = today), aBobbyRule(from = today.minusDays(1))),
+        plugins = Seq(futurePluginRule, aBobbyRule(from = today), aBobbyRule(name = "past.plugin", from = today.minusDays(1))))))
+
+      val result = await(service.getRules())
+
+      result.upcoming.libraries.length should be (1)
+      result.upcoming.libraries should contain (futureLibraryRule)
+      result.upcoming.plugins.length should be (1)
+      result.upcoming.plugins should contain (futurePluginRule)
+    }
+
+    "split rules into active dependencies if from date is not later than today" in {
+
+      val currentLibraryRule = aBobbyRule(name = "current.library", from = today)
+      val pastLibraryRule = aBobbyRule(name = "past.library", from = today.minusDays(1))
+      val currentPluginRule = aBobbyRule(name = "current.plugin", from = today)
+      val pastPluginRule = aBobbyRule(name = "past.plugin", from = today.minusDays(1))
+      when(connector.bobbyRules()).thenReturn(Future(new BobbyRuleSet(libraries = Seq(aBobbyRule(from = today.plusDays(1)), currentLibraryRule, pastLibraryRule),
+        plugins = Seq(aBobbyRule(from = today.plusDays(1)), currentPluginRule, pastPluginRule))))
+
+      val result = await(service.getRules())
+
+      result.active.libraries.length should be (2)
+      result.active.libraries should contain (currentLibraryRule)
+      result.active.libraries should contain (pastLibraryRule)
+      result.active.plugins.length should be (2)
+      result.active.plugins should contain (currentPluginRule)
+      result.active.plugins should contain (pastPluginRule)
+    }
+
+    "sort upcoming rules by date, starting with closest to today's date first" in {
+
+      val expectedRule = aBobbyRule(organisation = "b", from = today.plusDays(1))
+      val rules = Seq(aBobbyRule(organisation = "a", from = today.plusDays(2)),
+        expectedRule,
+        aBobbyRule(organisation = "a", from = today.minusDays(2)),
+        aBobbyRule(organisation = "b", from = today.minusDays(1)))
+      when(connector.bobbyRules()).thenReturn(Future(new BobbyRuleSet(rules, rules)))
+
+      val result = await(service.getRules())
+
+      result.upcoming.libraries.head should be (expectedRule)
+      result.upcoming.plugins.head should be (expectedRule)
+    }
+
+    "sort active rules by date, starting with closest to today's date first" in {
+
+      val expectedRule = aBobbyRule(organisation = "b", from = today.minusDays(1))
+      val rules = Seq(aBobbyRule(organisation = "a", from = today.plusDays(2)),
+        aBobbyRule(organisation = "b", from = today.plusDays(1)),
+        aBobbyRule(organisation = "b", from = today.minusDays(2)),
+        expectedRule)
+      when(connector.bobbyRules()).thenReturn(Future(new BobbyRuleSet(rules, rules)))
+
+      val result = await(service.getRules())
+
+      result.active.libraries.head should be (expectedRule)
+      result.active.plugins.head should be (expectedRule)
+    }
+
+    "sort by artifact group/name in ascending order" in {
+
+      val upcomingDate = today.plusDays(1)
+      val activeDate = today.minusDays(1)
+      val expectedUpcomingRule = aBobbyRule(organisation = "*", name = "b", from = upcomingDate)
+      val expectedActiveRule = aBobbyRule(organisation = "*", name = "b", from = activeDate)
+      val rules = Seq(aBobbyRule(organisation = "b", name = "a", from = upcomingDate), expectedUpcomingRule, aBobbyRule(organisation = "b", name = "a", from = activeDate), expectedActiveRule)
+      when(connector.bobbyRules()).thenReturn(Future(new BobbyRuleSet(rules, rules)))
+
+      val result = await(service.getRules())
+
+      result.upcoming.libraries.head should be (expectedUpcomingRule)
+      result.upcoming.plugins.head should be (expectedUpcomingRule)
+      result.active.libraries.head should be (expectedActiveRule)
+      result.active.plugins.head should be (expectedActiveRule)
+    }
+  }
+}


### PR DESCRIPTION
Displays list of all Bobby rules, in Upcoming and Active sections.

Note that the controller retrieves the results from service-configs each time this URL is accessed - the results are not cached.  A network error will simply display the generic "An error has occurred" page.  
