### PR TITLE
Bdog 366

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ npm-debug.log
 *.DS_Store
 .bloop/
 .metals/
+
+conf/local.conf

--- a/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterController.scala
@@ -23,29 +23,48 @@ import uk.gov.hmrc.cataloguefrontend.actions.VerifySignInStatus
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.shuttering._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 import scala.util.control.NonFatal
 
 @Singleton
 class ShutterController @Inject()(
-    mcc               : MessagesControllerComponents
-  , verifySignInStatus: VerifySignInStatus
-  , shutterStatePage  : ShutterStatePage
-  , shutterService    : ShutterService
-  )(implicit val ec: ExecutionContext)
+  mcc: MessagesControllerComponents,
+  verifySignInStatus: VerifySignInStatus,
+  shutterStatePage: ShutterStatePage,
+  frontendRoutesWarningPage: FrontendRouteWarningsPage,
+  shutterService: ShutterService
+)(implicit val ec: ExecutionContext)
     extends FrontendController(mcc) {
 
-    def allStates(envParam: String): Action[AnyContent] =
-      verifySignInStatus.async { implicit request =>
-        val env = Environment.parse(envParam).getOrElse(Environment.Production)
-        for {
-          currentState <- shutterService.findCurrentState(env)
-                            .recover {
-                              case NonFatal(ex) =>
-                                Logger.error(s"Could not retrieve currentState: ${ex.getMessage}", ex)
-                                Seq.empty
-                            }
-          page         =  shutterStatePage(currentState, env, request.isSignedIn)
-        } yield Ok(page)
+  def allStates(envParam: String): Action[AnyContent] =
+    verifySignInStatus.async { implicit request =>
+      val env = Environment.parse(envParam).getOrElse(Environment.Production)
+      for {
+        currentState <- shutterService
+                         .findCurrentState(env)
+                         .recover {
+                           case NonFatal(ex) =>
+                             Logger.error(s"Could not retrieve currentState: ${ex.getMessage}", ex)
+                             Seq.empty
+                         }
+        page = shutterStatePage(currentState, env, request.isSignedIn)
+      } yield Ok(page)
+    }
+
+  def frontendRouteWarnings(envParam: String, serviceName: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      val env = Environment.parse(envParam).getOrElse(Environment.Production)
+      for {
+        warnings <- shutterService
+                         .frontendRouteWarningsByAppAndEnv(serviceName, env)
+                         .recover {
+                           case NonFatal(ex) =>
+                             Logger.error(
+                               s"Could not retrieve frontend route warnings for service '$serviceName' in env: '$envParam': ${ex.getMessage}",
+                               ex)
+                             Seq.empty
+                         }
+        page = frontendRoutesWarningPage(warnings, env, serviceName)
+      } yield Ok(page)
     }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterService.scala
@@ -16,8 +16,6 @@
 
 package uk.gov.hmrc.cataloguefrontend.shuttering
 
-import java.time.LocalDateTime
-
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.http.{HeaderCarrier, Token}
 
@@ -46,6 +44,8 @@ class ShutterService @Inject()(
   def outagePageByAppAndEnv(serviceName: String, env: Environment)(implicit hc: HeaderCarrier): Future[Option[OutagePage]] =
     shutterConnector.outagePageByAppAndEnv(serviceName, env)
 
+  def frontendRouteWarningsByAppAndEnv(serviceName: String, env: Environment)(implicit hc: HeaderCarrier): Future[Seq[FrontendRouteWarning]] =
+    shutterConnector.frontendRouteWarningsByAppAndEnv(serviceName, env)
 
   def findCurrentState(env: Environment)(implicit hc: HeaderCarrier): Future[Seq[ShutterStateData]] =
     for {

--- a/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterServiceController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterServiceController.scala
@@ -22,29 +22,29 @@ import cats.syntax.all._
 import javax.inject.{Inject, Singleton}
 import play.api.data.{Form, Forms}
 import play.api.i18n.MessagesProvider
-import play.api.libs.json.{Format, Json}
-import play.api.mvc.{Action, MessagesControllerComponents, Request, Result, Session}
+import play.api.libs.json.Json
+import play.api.mvc.{MessagesControllerComponents, Request, Result, Session}
 import play.twirl.api.Html
-import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import uk.gov.hmrc.cataloguefrontend.actions.UmpAuthActionBuilder
-import uk.gov.hmrc.cataloguefrontend.connector.SlugInfoFlag
-import uk.gov.hmrc.cataloguefrontend.shuttering.{ routes => appRoutes }
-import views.html.shuttering.shutterService.{Page1, Page2, Page3, Page4}
+import uk.gov.hmrc.cataloguefrontend.shuttering.{routes => appRoutes}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.shuttering.shutterService._
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ShutterServiceController @Inject()(
-     mcc                 : MessagesControllerComponents
-   , shutterService      : ShutterService
-   , page1               : Page1
-   , page2               : Page2
-   , page3               : Page3
-   , page4               : Page4
-   , umpAuthActionBuilder: UmpAuthActionBuilder
-   )(implicit val ec : ExecutionContext
-   ) extends FrontendController(mcc)
-        with play.api.i18n.I18nSupport {
+  mcc: MessagesControllerComponents,
+  shutterService: ShutterService,
+  page1: Page1,
+  page2a: Page2a,
+  page2: Page2,
+  page3: Page3,
+  page4: Page4,
+  umpAuthActionBuilder: UmpAuthActionBuilder
+)(implicit val ec: ExecutionContext)
+    extends FrontendController(mcc)
+    with play.api.i18n.I18nSupport {
 
   import ShutterServiceController._
 
@@ -59,8 +59,8 @@ class ShutterServiceController @Inject()(
   private def showPage1(form: Form[Step1Form])(implicit request: Request[Any]): Future[Html] =
     for {
       shutterStates <- shutterService.getShutterStates
-      envs          =  Environment.values
-      statusValues  =  ShutterStatusValue.values
+      envs         = Environment.values
+      statusValues = ShutterStatusValue.values
       shutterGroups <- shutterService.shutterGroups
     } yield page1(form, shutterStates, envs, statusValues, shutterGroups)
 
@@ -68,62 +68,125 @@ class ShutterServiceController @Inject()(
     withGroup.async { implicit request =>
       for {
         shutterStates <- shutterService.getShutterStates
-        step1f        =  if (serviceName.isDefined || env.isDefined) {
-                           Step1Form(
-                               serviceNames = serviceName.toSeq
-                             , env          = env.getOrElse("")
-                             , status       = statusFor(shutterStates)(serviceName, env).fold("")(_.asString)
-                             )
-                         } else fromSession(request.session).flatMap(_.step1) match {
-                           case Some(step1Out) => Step1Form(
-                                                      serviceNames = step1Out.serviceNames
-                                                    , env          = step1Out.env.asString
-                                                    , status       = step1Out.status.asString
-                                                    )
-                           case None          => Step1Form(serviceNames = Seq.empty, env = "", status = "")
-                         }
-        html          <- showPage1(step1Form.fill(step1f)).map(Ok(_))
+        step1f = if (serviceName.isDefined || env.isDefined) {
+          Step1Form(
+            serviceNames = serviceName.toSeq,
+            env          = env.getOrElse(""),
+            status       = statusFor(shutterStates)(serviceName, env).fold("")(_.asString)
+          )
+        } else
+          fromSession(request.session).flatMap(_.step1) match {
+            case Some(step1Out) =>
+              Step1Form(
+                serviceNames = step1Out.serviceNames,
+                env          = step1Out.env.asString,
+                status       = step1Out.status.asString
+              )
+            case None => Step1Form(serviceNames = Seq.empty, env = "", status = "")
+          }
+        html <- showPage1(step1Form.fill(step1f)).map(Ok(_))
       } yield html
     }
 
-  def statusFor(shutterStates: Seq[ShutterState])(optServiceName: Option[String], optEnv: Option[String]): Option[ShutterStatusValue] =
+  def statusFor(shutterStates: Seq[ShutterState])(
+    optServiceName: Option[String],
+    optEnv: Option[String]): Option[ShutterStatusValue] =
     for {
       serviceName <- optServiceName
       envStr      <- optEnv
       env         <- Environment.parse(envStr)
       status      <- shutterStates.find(_.name == serviceName).map(_.statusFor(env).value)
-    } yield status match {
-      case ShutterStatusValue.Shuttered   => ShutterStatusValue.Unshuttered
-      case ShutterStatusValue.Unshuttered => ShutterStatusValue.Shuttered
-    }
+    } yield
+      status match {
+        case ShutterStatusValue.Shuttered   => ShutterStatusValue.Unshuttered
+        case ShutterStatusValue.Unshuttered => ShutterStatusValue.Shuttered
+      }
 
   def step1Post =
     withGroup.async { implicit request =>
       (for {
-         sf       <- step1Form
-                       .bindFromRequest
-                       .fold(
-                           hasErrors = formWithErrors => EitherT.left(showPage1(formWithErrors).map(BadRequest(_)))
-                         , success   = data           => EitherT.pure[Future, Result](data)
-                         )
-         env      <- Environment.parse(sf.env) match {
-                       case Some(env) => EitherT.pure[Future, Result](env)
-                       case None      => EitherT.left(showPage1(step1Form.bindFromRequest).map(BadRequest(_)))
-                     }
-         status   <- ShutterStatusValue.parse(sf.status) match {
-                       case Some(status) => EitherT.pure[Future, Result](status)
-                       case None         => EitherT.left(showPage1(step1Form.bindFromRequest).map(BadRequest(_)))
-                     }
-         step1Out =  Step1Out(sf.serviceNames, env, status)
-       } yield status match {
-         case ShutterStatusValue.Shuttered   => Redirect(appRoutes.ShutterServiceController.step2Get)
-                                                  .withSession(request.session + updateFlowState(request.session)(_.copy(step1 = Some(step1Out))))
-         case ShutterStatusValue.Unshuttered => Redirect(appRoutes.ShutterServiceController.step3Get)
-                                                  .withSession(request.session + updateFlowState(request.session)(_.copy( step1 = Some(step1Out)
-                                                                                                                        , step2 = Some(Step2Out(reason = "", outageMessage = "", requiresOutageMessage = false))
-                                                                                                                        )))
-       }
-      ).merge
+        sf <- step1Form.bindFromRequest
+               .fold(
+                 hasErrors = formWithErrors => EitherT.left(showPage1(formWithErrors).map(BadRequest(_))),
+                 success   = data => EitherT.pure[Future, Result](data)
+               )
+        env <- Environment.parse(sf.env) match {
+                case Some(env) => EitherT.pure[Future, Result](env)
+                case None      => EitherT.left(showPage1(step1Form.bindFromRequest).map(BadRequest(_)))
+              }
+        status <- ShutterStatusValue.parse(sf.status) match {
+                   case Some(status) => EitherT.pure[Future, Result](status)
+                   case None         => EitherT.left(showPage1(step1Form.bindFromRequest).map(BadRequest(_)))
+                 }
+        step1Out = Step1Out(sf.serviceNames, env, status)
+      } yield
+        status match {
+          case ShutterStatusValue.Shuttered =>
+            Redirect(appRoutes.ShutterServiceController.step2aGet)
+              .withSession(request.session + updateFlowState(request.session)(_.copy(step1 = Some(step1Out))))
+          case ShutterStatusValue.Unshuttered =>
+            Redirect(appRoutes.ShutterServiceController.step3Get)
+              .withSession(
+                request.session + updateFlowState(request.session)(
+                  _.copy(
+                    step1 = Some(step1Out),
+                    step2 = Some(Step2Out(reason = "", outageMessage = "", requiresOutageMessage = false)))))
+        }).merge
+    }
+
+  // --------------------------------------------------------------------------
+  // Step2a
+  //
+  // Review frontend-route warnings (if any) (only applies to Shutter - not Unshutter)
+  //
+  // --------------------------------------------------------------------------
+  private def showPage2a(form2a: Form[Step2aForm], step1Out: Step1Out)(implicit request: Request[Any]): Future[Html] =
+    for {
+      frontendRouteWarnings <- step1Out.serviceNames.toList
+                                .map(
+                                  serviceName =>
+                                    shutterService
+                                      .frontendRouteWarningsByAppAndEnv(serviceName, step1Out.env)
+                                      .map(w => ServiceAndRouteWarnings(serviceName, w)))
+                                .sequence
+    } yield page2a(form2a, step1Out, frontendRouteWarnings)
+
+  def step2aGet =
+    withGroup.async { implicit request =>
+      (for {
+        step1Out <- EitherT.fromOption[Future](
+                     fromSession(request.session)
+                       .flatMap(_.step1),
+                     Redirect(appRoutes.ShutterServiceController.step1Post)
+                   )
+        step2af = fromSession(request.session).flatMap(_.step2a) match {
+          case Some(step2aOut) =>
+            Step2aForm(
+              confirm = step2aOut.confirmed
+            )
+          case None => Step2aForm(confirm = false)
+        }
+        html <- EitherT.right[Result](showPage2a(step2aForm.fill(step2af), step1Out).map(Ok(_)))
+      } yield html).merge
+    }
+
+  def step2aPost =
+    withGroup.async { implicit request =>
+      (for {
+        step1Out <- EitherT.fromOption[Future](
+                     fromSession(request.session)
+                       .flatMap(_.step1),
+                     Redirect(appRoutes.ShutterServiceController.step1Post)
+                   )
+        sf <- step2aForm.bindFromRequest
+               .fold(
+                 hasErrors = formWithErrors => EitherT.left(showPage2a(formWithErrors, step1Out).map(BadRequest(_))),
+                 success   = data => EitherT.pure[Future, Result](data)
+               )
+        step2aOut = Step2aOut(sf.confirm)
+      } yield
+        Redirect(appRoutes.ShutterServiceController.step2Get)
+          .withSession(request.session + updateFlowState(request.session)(fs => fs.copy(step2a = Some(step2aOut))))).merge
     }
 
   // --------------------------------------------------------------------------
@@ -135,65 +198,65 @@ class ShutterServiceController @Inject()(
 
   private def showPage2(form: Form[Step2Form], step1Out: Step1Out)(implicit request: Request[Any]): Future[Html] =
     for {
-      outagePages           <- step1Out.serviceNames.toList.traverse[Future, Option[OutagePage]](serviceName =>
-                                 shutterService
-                                   .outagePageByAppAndEnv(serviceName, step1Out.env)
-                               ).map(_.collect { case Some(op) => op })
+      outagePages <- step1Out.serviceNames.toList
+                      .traverse[Future, Option[OutagePage]](serviceName =>
+                        shutterService
+                          .outagePageByAppAndEnv(serviceName, step1Out.env))
+                      .map(_.collect { case Some(op) => op })
       outageMessageTemplate = outagePages
-                                .flatMap(op => op.templatedMessages.map((op, _)))
-                                .headOption
+        .flatMap(op => op.templatedMessages.map((op, _)))
+        .headOption
       requiresOutageMessage = outageMessageTemplate.isDefined || outagePages.flatMap(_.warnings).nonEmpty
       outageMessageSrc      = outageMessageTemplate.map(_._1)
       defaultOutageMessage  = outageMessageTemplate.fold("")(_._2.innerHtml)
       outagePageStatus      = shutterService.toOutagePageStatus(step1Out.serviceNames, outagePages)
-      form2                 = step2Form.fill {
-                                val s2f = form.get
-                                if (s2f.outageMessage.isEmpty) s2f.copy(outageMessage = defaultOutageMessage) else s2f
-                              }
-    } yield page2(form2, step1Out, requiresOutageMessage, outageMessageSrc, defaultOutageMessage, outagePageStatus)
-
+      back = if (step1Out.status == ShutterStatusValue.Shuttered)
+        appRoutes.ShutterServiceController.step2aGet
+      else appRoutes.ShutterServiceController.step1Post
+      form2 = step2Form.fill {
+        val s2f = form.get
+        if (s2f.outageMessage.isEmpty) s2f.copy(outageMessage = defaultOutageMessage) else s2f
+      }
+    } yield page2(form2, step1Out, requiresOutageMessage, outageMessageSrc, defaultOutageMessage, outagePageStatus, back)
 
   def step2Get =
     withGroup.async { implicit request =>
       (for {
-         step1Out      <- EitherT.fromOption[Future](
-                              fromSession(request.session)
-                                .flatMap(_.step1)
-                            , Redirect(appRoutes.ShutterServiceController.step1Post)
-                            )
-         step2f        =  fromSession(request.session).flatMap(_.step2) match {
-                            case Some(step2Out) => Step2Form(
-                                                       reason                = step2Out.reason
-                                                     , outageMessage         = step2Out.outageMessage
-                                                     , requiresOutageMessage = step2Out.requiresOutageMessage
-                                                     )
-                            case None           => Step2Form(reason = "", outageMessage = "", requiresOutageMessage = true)
-                          }
-         html          <- EitherT.right[Result](showPage2(step2Form.fill(step2f), step1Out).map(Ok(_)))
-       } yield html
-      ).merge
-  }
+        step1Out <- EitherT.fromOption[Future](
+                     fromSession(request.session)
+                       .flatMap(_.step1),
+                     Redirect(appRoutes.ShutterServiceController.step1Post)
+                   )
+        step2f = fromSession(request.session).flatMap(_.step2) match {
+          case Some(step2Out) =>
+            Step2Form(
+              reason                = step2Out.reason,
+              outageMessage         = step2Out.outageMessage,
+              requiresOutageMessage = step2Out.requiresOutageMessage
+            )
+          case None => Step2Form(reason = "", outageMessage = "", requiresOutageMessage = true)
+        }
+        html <- EitherT.right[Result](showPage2(step2Form.fill(step2f), step1Out).map(Ok(_)))
+      } yield html).merge
+    }
 
   def step2Post =
     withGroup.async { implicit request =>
-      val envs          =  Environment.values
-      val statusValues  =  ShutterStatusValue.values
       (for {
-         step1Out <- EitherT.fromOption[Future](
-                         fromSession(request.session)
-                           .flatMap(_.step1)
-                       , Redirect(appRoutes.ShutterServiceController.step1Post)
-                       )
-         sf       <- step2Form
-                       .bindFromRequest
-                       .fold(
-                           hasErrors = formWithErrors => EitherT.left(showPage2(formWithErrors, step1Out).map(BadRequest(_)))
-                         , success   = data           => EitherT.pure[Future, Result](data)
-                         )
-         step2Out =  Step2Out(sf.reason, sf.outageMessage, sf.requiresOutageMessage)
-       } yield Redirect(appRoutes.ShutterServiceController.step3Get)
-                .withSession(request.session + updateFlowState(request.session)(fs => fs.copy(step2 = Some(step2Out))))
-      ).merge
+        step1Out <- EitherT.fromOption[Future](
+                     fromSession(request.session)
+                       .flatMap(_.step1),
+                     Redirect(appRoutes.ShutterServiceController.step1Post)
+                   )
+        sf <- step2Form.bindFromRequest
+               .fold(
+                 hasErrors = formWithErrors => EitherT.left(showPage2(formWithErrors, step1Out).map(BadRequest(_))),
+                 success   = data => EitherT.pure[Future, Result](data)
+               )
+        step2Out = Step2Out(sf.reason, sf.outageMessage, sf.requiresOutageMessage)
+      } yield
+        Redirect(appRoutes.ShutterServiceController.step3Get)
+          .withSession(request.session + updateFlowState(request.session)(fs => fs.copy(step2 = Some(step2Out))))).merge
     }
 
   // --------------------------------------------------------------------------
@@ -203,58 +266,58 @@ class ShutterServiceController @Inject()(
   //
   // --------------------------------------------------------------------------
 
-  private def showPage3(form3: Form[Step3Form], step1Out: Step1Out, step2Out: Step2Out)(implicit request: Request[Any]): Html = {
-    val back = if (step1Out.status == ShutterStatusValue.Shuttered)
-                 appRoutes.ShutterServiceController.step2Get
-               else appRoutes.ShutterServiceController.step1Post
+  private def showPage3(form3: Form[Step3Form], step1Out: Step1Out, step2Out: Step2Out)(
+    implicit request: Request[Any]): Html = {
+    val back =
+      if (step1Out.status == ShutterStatusValue.Shuttered)
+        appRoutes.ShutterServiceController.step2Get
+      else appRoutes.ShutterServiceController.step1Post
     page3(form3, step1Out, step2Out, back)
   }
 
   def step3Get =
     withGroup { implicit request =>
       (for {
-         flowState <- fromSession(request.session)
-         step1Out  <- flowState.step1
-         step2Out  <- flowState.step2
-         html      =  showPage3(step3Form.fill(Step3Form(confirm = false)), step1Out, step2Out)
-       } yield Ok(html)
-      ).getOrElse(Redirect(appRoutes.ShutterServiceController.step1Post))
+        flowState <- fromSession(request.session)
+        step1Out  <- flowState.step1
+        step2Out  <- flowState.step2
+        html = showPage3(step3Form.fill(Step3Form(confirm = false)), step1Out, step2Out)
+      } yield Ok(html)).getOrElse(Redirect(appRoutes.ShutterServiceController.step1Post))
     }
 
   def step3Post =
     withGroup.async { implicit request =>
       (for {
-         step1Out <- EitherT.fromOption[Future](
-                         fromSession(request.session).flatMap(_.step1)
-                       , Redirect(appRoutes.ShutterServiceController.step1Post)
-                       )
-         step2Out <- EitherT.fromOption[Future](
-                         fromSession(request.session).flatMap(_.step2)
-                       , Redirect(appRoutes.ShutterServiceController.step2Get)
-                       )
-         _        <- step3Form
-                       .bindFromRequest
-                       .fold(
-                           hasErrors = formWithErrors => EitherT.left(Future(showPage3(formWithErrors, step1Out, step2Out)).map(BadRequest(_)))
-                         , success   = data           => EitherT.pure[Future, Result](())
-                         )
-         status   =  step1Out.status match {
-                        case ShutterStatusValue.Shuttered => ShutterStatus.Shuttered(
-                                                                 reason        = Some(step2Out.reason).filter(_.nonEmpty)
-                                                               , outageMessage = Some(step2Out.outageMessage).filter(_.nonEmpty)
-                                                               )
-                        case ShutterStatusValue.Unshuttered => ShutterStatus.Unshuttered
-                     }
-         _        <- step1Out.serviceNames.toList.traverse_[EitherT[Future, Result, ?], Unit] { serviceName =>
-                       EitherT.right[Result] {
-                         shutterService
-                           .updateShutterStatus(request.token, serviceName, step1Out.env, status)
-                       }
-                    }
-       } yield Redirect(appRoutes.ShutterServiceController.step4Get)
-      ).merge
+        step1Out <- EitherT.fromOption[Future](
+                     fromSession(request.session).flatMap(_.step1),
+                     Redirect(appRoutes.ShutterServiceController.step1Post)
+                   )
+        step2Out <- EitherT.fromOption[Future](
+                     fromSession(request.session).flatMap(_.step2),
+                     Redirect(appRoutes.ShutterServiceController.step2Get)
+                   )
+        _ <- step3Form.bindFromRequest
+              .fold(
+                hasErrors = formWithErrors =>
+                  EitherT.left(Future(showPage3(formWithErrors, step1Out, step2Out)).map(BadRequest(_))),
+                success = data => EitherT.pure[Future, Result](())
+              )
+        status = step1Out.status match {
+          case ShutterStatusValue.Shuttered =>
+            ShutterStatus.Shuttered(
+              reason        = Some(step2Out.reason).filter(_.nonEmpty),
+              outageMessage = Some(step2Out.outageMessage).filter(_.nonEmpty)
+            )
+          case ShutterStatusValue.Unshuttered => ShutterStatus.Unshuttered
+        }
+        _ <- step1Out.serviceNames.toList.traverse_[EitherT[Future, Result, ?], Unit] { serviceName =>
+              EitherT.right[Result] {
+                shutterService
+                  .updateShutterStatus(request.token, serviceName, step1Out.env, status)
+              }
+            }
+      } yield Redirect(appRoutes.ShutterServiceController.step4Get)).merge
     }
-
 
   // --------------------------------------------------------------------------
   // Step4
@@ -281,23 +344,23 @@ object ShutterServiceController {
   def step1Form(implicit messagesProvider: MessagesProvider) =
     Form(
       Forms.mapping(
-          "serviceName" -> Forms.seq(Forms.text).verifying(notEmptySeq)
-        , "env"         -> Forms.text.verifying(notEmpty)
-        , "status"      -> Forms.text.verifying(notEmpty)
-        )(Step1Form.apply)(Step1Form.unapply)
+        "serviceName" -> Forms.seq(Forms.text).verifying(notEmptySeq),
+        "env"         -> Forms.text.verifying(notEmpty),
+        "status"      -> Forms.text.verifying(notEmpty)
+      )(Step1Form.apply)(Step1Form.unapply)
     )
 
   case class Step1Form(
-      serviceNames: Seq[String]
-    , env         : String
-    , status      : String
-    )
+    serviceNames: Seq[String],
+    env: String,
+    status: String
+  )
 
   case class Step1Out(
-      serviceNames: Seq[String]
-    , env         : Environment
-    , status      : ShutterStatusValue
-    )
+    serviceNames: Seq[String],
+    env: Environment,
+    status: ShutterStatusValue
+  )
 
   private implicit val step1OutFormats = {
     implicit val ef  = Environment.format
@@ -305,28 +368,47 @@ object ShutterServiceController {
     Json.format[Step1Out]
   }
 
+  // -- Step 2a -------------------------
+  def step2aForm(implicit messagesProvider: MessagesProvider) =
+    Form(
+      Forms
+        .mapping(
+          "confirm" -> Forms.boolean
+        )(Step2aForm.apply)(Step2aForm.unapply)
+        .verifying("You must tick to confirm you have acknowledged the frontend-route warnings", _.confirm == true)
+    )
+  case class Step2aForm(confirm: Boolean)
+
+  case class Step2aOut(
+    confirmed: Boolean
+  )
+
+  private implicit val step2aOutFormats = {
+    Json.format[Step2aOut]
+  }
+
   // -- Step 2 -------------------------
 
   def step2Form(implicit messagesProvider: MessagesProvider) =
     Form(
       Forms.mapping(
-          "reason"                -> Forms.text
-        , "outageMessage"         -> Forms.text
-        , "requiresOutageMessage" -> Forms.boolean
-        )(Step2Form.apply)(Step2Form.unapply)
+        "reason"                -> Forms.text,
+        "outageMessage"         -> Forms.text,
+        "requiresOutageMessage" -> Forms.boolean
+      )(Step2Form.apply)(Step2Form.unapply)
     )
 
   case class Step2Form(
-      reason               : String
-    , outageMessage        : String
-    , requiresOutageMessage: Boolean
-    )
+    reason: String,
+    outageMessage: String,
+    requiresOutageMessage: Boolean
+  )
 
   case class Step2Out(
-      reason               : String
-    , outageMessage        : String
-    , requiresOutageMessage: Boolean
-    )
+    reason: String,
+    outageMessage: String,
+    requiresOutageMessage: Boolean
+  )
 
   private implicit val step2OutFormats =
     Json.format[Step2Out]
@@ -335,31 +417,33 @@ object ShutterServiceController {
 
   def step3Form(implicit messagesProvider: MessagesProvider) =
     Form(
-      Forms.mapping(
-          "confirm"        -> Forms.boolean
-        )(Step3Form.apply)(Step3Form.unapply).verifying("You must check confirmation for Production", _.confirm == true)
+      Forms
+        .mapping(
+          "confirm" -> Forms.boolean
+        )(Step3Form.apply)(Step3Form.unapply)
+        .verifying("You must check confirmation for Production", _.confirm == true)
     )
 
   case class Step3Form(
-      confirm      : Boolean
-    )
-
+    confirm: Boolean
+  )
 
   // -- Flow State -------------------------
-
 
   val SessionKey = "ShutterServiceController"
 
   case class FlowState(
-      step1: Option[Step1Out]
-    , step2: Option[Step2Out]
-    )
+    step1: Option[Step1Out],
+    step2a: Option[Step2aOut],
+    step2: Option[Step2Out]
+  )
+
+  case class ServiceAndRouteWarnings(serviceName: String, warnings: Seq[FrontendRouteWarning])
 
   private implicit val flowStateFormats = Json.format[FlowState]
 
-
   def updateFlowState(session: Session)(f: FlowState => FlowState): (String, String) = {
-    val updatedState = f(fromSession(session).getOrElse(FlowState(None, None)))
+    val updatedState = f(fromSession(session).getOrElse(FlowState(None, None, None)))
     (SessionKey -> Json.stringify(Json.toJson(updatedState)))
   }
 

--- a/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterServiceController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterServiceController.scala
@@ -421,7 +421,7 @@ object ShutterServiceController {
         .mapping(
           "confirm" -> Forms.boolean
         )(Step3Form.apply)(Step3Form.unapply)
-        .verifying("You must check confirmation for Production", _.confirm == true)
+        .verifying("You must tick to confirm you have acknowledged you are changing production services!", _.confirm == true)
     )
 
   case class Step3Form(

--- a/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterStateModel.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterStateModel.scala
@@ -30,7 +30,7 @@ object Environment {
   case object Staging         extends Environment { val asString = "staging"      }
   case object Dev             extends Environment { val asString = "development"  }
 
-  val values = List(Production, ExternalTest, QA, Staging, Dev)
+  val values: List[Environment] = List(Production, ExternalTest, QA, Staging, Dev)
 
   def parse(s: String): Option[Environment] =
     values.find(_.asString.toLowerCase == s.toLowerCase.replaceAll(" ", ""))

--- a/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterStateModel.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterStateModel.scala
@@ -17,8 +17,9 @@
 package uk.gov.hmrc.cataloguefrontend.shuttering
 
 import java.time.Instant
-import play.api.libs.json.{Format, Json, JsError, JsObject, JsValue, JsPath, JsResult, JsString, JsSuccess, Reads, Writes, __}
+
 import play.api.libs.functional.syntax._
+import play.api.libs.json._
 
 
 sealed trait Environment { def asString: String }
@@ -386,3 +387,14 @@ case class OutagePageStatus(
     serviceName : String
   , warning     : Option[(String, String)]
   )
+
+case class FrontendRouteWarning(name: String, message: String, consequence: String, ruleConfigurationURL: String)
+
+object FrontendRouteWarning {
+  val reads: Reads[FrontendRouteWarning] =
+    ( (__ \ "name"   ).read[String]
+      ~ (__ \ "message").read[String]
+      ~ (__ \ "consequence").read[String]
+      ~ (__ \ "ruleConfigurationURL").read[String]
+      )(FrontendRouteWarning.apply _)
+}

--- a/app/views/partials/form_warnings.scala.html
+++ b/app/views/partials/form_warnings.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@(form                  : Form[_])(implicit request       : Request[_]
+, messagesProvider: MessagesProvider
+)
+
+@if(form.hasGlobalErrors) {
+<div class="alert alert-error error">
+    <a class="close" data-dismiss="alert">×</a>
+    <ul>
+        @form.globalErrors.map { error =>
+        <li>@error.format</li>
+        }
+    </ul>
+</div>
+}

--- a/app/views/shuttering/FrontendRouteWarningsPage.scala.html
+++ b/app/views/shuttering/FrontendRouteWarningsPage.scala.html
@@ -1,0 +1,77 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, FrontendRouteWarning}
+@import uk.gov.hmrc.cataloguefrontend.ViewMessages
+
+@this(viewMessages: ViewMessages)
+
+@( warnings: Seq[FrontendRouteWarning]
+ , selectedEnv  : Environment
+ , selectedService : String
+ )(implicit request: Request[_])
+
+@standard_layout(s"Frontend Route Warnings: ${selectedEnv.asString}") {
+
+  <header>
+      <h1>Frontend Route Warnings for: @selectedService</h1>
+  </header>
+
+  <section>
+
+    <div class="row">
+      <ul id="environment" class="nav nav-tabs">
+          @Environment.values.map(envOption)
+      </ul>
+  </div>
+
+  <div class="row tabs-bottom">
+
+      <table id="frontend-route-warnings-table" class="table table-striped">
+          <thead>
+              <tr>
+                  <th>Name</th>
+                  <th>Message</th>
+                  <th>Consequence</th>
+                  <th>Source</th>
+              </tr>
+          </thead>
+
+          <tbody>
+              @warnings.map(routeWarningRow)
+          </tbody>
+
+      </table>
+
+  </div>
+  </section>
+
+}
+
+@envOption(env: Environment) = {
+  <li id="tab-@env.asString" class="navbar-item @if(env == selectedEnv){active}">
+      <a href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterController.frontendRouteWarnings(env.asString, selectedService)" class="navbar-link">@env.toString</a>
+  </li>
+}
+
+@routeWarningRow(warning: FrontendRouteWarning) = {
+  <tr class="shutter-row frontend-route-warning">
+      <td class="frontend-route-warning-name">@warning.name</td>
+      <td class="frontend-route-warning-message">@warning.message</td>
+      <td class="frontend-route-warning-consequence">@warning.consequence</td>
+      <td class="frontend-route-warning-ruleConfigurationURL"><a href="@warning.ruleConfigurationURL">Link</a></td>
+  </tr>
+}

--- a/app/views/shuttering/FrontendRouteWarningsPage.scala.html
+++ b/app/views/shuttering/FrontendRouteWarningsPage.scala.html
@@ -38,23 +38,28 @@
       </ul>
   </div>
 
-  <div class="row tabs-bottom">
+  <div class="row tabs-bottom col-xs-12">
 
-      <table id="frontend-route-warnings-table" class="table table-striped">
-          <thead>
+      @if(warnings.nonEmpty) {
+          <table id="frontend-route-warnings-table" class="table table-striped">
+              <thead>
               <tr>
                   <th>Name</th>
                   <th>Message</th>
                   <th>Consequence</th>
                   <th>Source</th>
               </tr>
-          </thead>
+              </thead>
 
-          <tbody>
-              @warnings.map(routeWarningRow)
-          </tbody>
+              <tbody>
+                @warnings.map(routeWarningRow)
+              </tbody>
 
-      </table>
+          </table>
+
+      } else {
+        <p>There are no frontend-route warnings for this service in this environment</p>
+      }
 
   </div>
   </section>

--- a/app/views/shuttering/FrontendRouteWarningsPage.scala.html
+++ b/app/views/shuttering/FrontendRouteWarningsPage.scala.html
@@ -19,7 +19,7 @@
 
 @this(viewMessages: ViewMessages)
 
-@( warnings: Seq[FrontendRouteWarning]
+@( warningsMap: Map[Environment, Seq[FrontendRouteWarning]]
  , selectedEnv  : Environment
  , selectedService : String
  )(implicit request: Request[_])
@@ -39,28 +39,30 @@
   </div>
 
   <div class="row tabs-bottom col-xs-12">
+      @defining(warningsMap.get(selectedEnv).getOrElse(Seq.empty)) { warnings =>
 
-      @if(warnings.nonEmpty) {
-          <table id="frontend-route-warnings-table" class="table table-striped">
-              <thead>
-              <tr>
-                  <th>Name</th>
-                  <th>Message</th>
-                  <th>Consequence</th>
-                  <th>Source</th>
-              </tr>
-              </thead>
+          @if(warnings.nonEmpty) {
+              <table id="frontend-route-warnings-table" class="table table-striped">
+                  <thead>
+                  <tr>
+                      <th>Name</th>
+                      <th>Message</th>
+                      <th>Consequence</th>
+                      <th>Source</th>
+                  </tr>
+                  </thead>
 
-              <tbody>
-                @warnings.map(routeWarningRow)
-              </tbody>
+                  <tbody>
+                    @warnings.map(routeWarningRow)
+                  </tbody>
 
-          </table>
+              </table>
 
-      } else {
-        <p>There are no frontend-route warnings for this service in this environment</p>
+          } else {
+            <p>There are no frontend-route warnings for this service in this environment</p>
+          }
+
       }
-
   </div>
   </section>
 
@@ -68,8 +70,12 @@
 
 @envOption(env: Environment) = {
   <li id="tab-@env.asString" class="navbar-item @if(env == selectedEnv){active}">
-      <a href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterController.frontendRouteWarnings(env.asString, selectedService)" class="navbar-link">@env.toString</a>
+      <a href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterController.frontendRouteWarnings(env.asString, selectedService)" class="navbar-link">@env.toString (@envWarningCount(env))</a>
   </li>
+}
+
+@envWarningCount(env: Environment) = {
+    @warningsMap.get(env).getOrElse(Seq.empty).size
 }
 
 @routeWarningRow(warning: FrontendRouteWarning) = {

--- a/app/views/shuttering/shutterService/Page1.scala.html
+++ b/app/views/shuttering/shutterService/Page1.scala.html
@@ -18,6 +18,7 @@
 @import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, ShutterGroup, ShutterStatusValue, ShutterState}
 @import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.Step1Form
 @import helper._
+@import partials.form_warnings
 
 @this(viewMessages: ViewMessages)
 
@@ -38,16 +39,7 @@
 
   <div id="service-list">
 
-    @if(form.hasGlobalErrors) {
-      <div class="alert alert-error error">
-        <a class="close" data-dismiss="alert">×</a>
-        <ul>
-          @form.globalErrors.map { error =>
-            <li>@error.format</li>
-          }
-        </ul>
-      </div>
-    }
+    @form_warnings(form)
 
     <div class="board">
       <div class="board__body">

--- a/app/views/shuttering/shutterService/Page2.scala.html
+++ b/app/views/shuttering/shutterService/Page2.scala.html
@@ -27,6 +27,7 @@
  , outageMessageSrc      : Option[OutagePage]
  , defaultOutageMessage  : String
  , outagePages           : Seq[OutagePageStatus]
+ , back                  : Call
  )(implicit request         : Request[_]
           , messagesProvider: MessagesProvider
           )
@@ -34,7 +35,7 @@
 @standard_layout(s"Shutter Service") {
 
   <header>
-    <h1>Shutter Service</h1>
+    <h1>Shutter Service: Check outage-pages</h1>
   </header>
 
   <div id="service-list">
@@ -128,7 +129,7 @@
                   <p>@Html(outageMessageSrc.map(src => s"The templated value was extracted from the <a target='_blank' href='${src.outagePageURL}'>${src.serviceName} outage page</a>.").getOrElse(""))</p>
               </div>
               <div class="col-sm-4" style="display:table-cell; float:none; vertical-align: middle;">
-                <a id="back-btn" href="javascript:revertTemplate()" class="btn btn-default">
+                <a href="javascript:revertTemplate()" class="btn btn-default">
                   Revert to template
                 </a>
               </div>
@@ -149,7 +150,7 @@
           </div>
           <div class="row">
             <div class="col-sm-6">
-              <a id="back-btn" href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterServiceController.step1Get(None, None)" class="btn btn-default">
+              <a id="back-btn" href="@back" class="btn btn-default">
                 <span class="glyphicon glyphicon-chevron-left"></span>
                 Back
               </a>

--- a/app/views/shuttering/shutterService/Page2.scala.html
+++ b/app/views/shuttering/shutterService/Page2.scala.html
@@ -18,6 +18,7 @@
 @import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, OutagePage, OutagePageStatus, ShutterStatusValue, ShutterState}
 @import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2Form}
 @import helper._
+@import partials.form_warnings
 
 @this(viewMessages: ViewMessages)
 
@@ -40,16 +41,7 @@
 
   <div id="service-list">
 
-    @if(form.hasGlobalErrors) {
-      <div class="alert alert-error error">
-        <a class="close" data-dismiss="alert">×</a>
-        <ul>
-          @form.globalErrors.map { error =>
-            <li>@error.format</li>
-          }
-        </ul>
-      </div>
-    }
+    @form_warnings(form)
 
     <div class="board">
       <div class="board__body">

--- a/app/views/shuttering/shutterService/Page2a.scala.html
+++ b/app/views/shuttering/shutterService/Page2a.scala.html
@@ -70,7 +70,8 @@
                 <div class="col-sm-12">
                     <div class="panel panel-warning">
                         <div class="panel-heading"><span class="glyphicon glyphicon-warning-sign"></span>
-                            There were some (@{frontendRouteWarnings.map(_.warnings.size).sum}) warnings found with the Frontend Routes.
+                            There were some (@{frontendRouteWarnings.map(_.warnings.size).sum}) warnings found with the
+                            Frontend Routes.
                         </div>
                         <div class="panel-body">
                             Please review, you can still continue to shutter.
@@ -112,11 +113,9 @@
                             <input type="checkbox" id="confirm" name="confirm" value="true">
                             <label for="confirm">I confirm</label>
                         </div>
-
                     </div>
                     </td>
                 </div>
-
             </div>
 
             <div class="row">

--- a/app/views/shuttering/shutterService/Page2a.scala.html
+++ b/app/views/shuttering/shutterService/Page2a.scala.html
@@ -76,7 +76,7 @@
                         <div class="panel-body">
                             Please review, you can still continue to shutter.
                             <br/><br/>
-                            <table class="table table-bordered">
+                            <table id="frontend-route-warnings" class="table table-bordered">
                                 <thead>
                                 <tr>
                                     <td>Service</td>

--- a/app/views/shuttering/shutterService/Page2a.scala.html
+++ b/app/views/shuttering/shutterService/Page2a.scala.html
@@ -1,0 +1,152 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.ViewMessages
+@import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, ShutterStatusValue, ShutterState}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2aForm, ServiceAndRouteWarnings}
+@import helper._
+
+@this(viewMessages: ViewMessages)
+
+@( form                  : Form[Step2aForm]
+, step1Out               : Step1Out
+, frontendRouteWarnings  : Seq[ServiceAndRouteWarnings]
+)(implicit request       : Request[_]
+, messagesProvider: MessagesProvider
+)
+
+@standard_layout(s"Shutter Service") {
+
+<header>
+    <h1>Shutter Service: Check Frontend Routes</h1>
+</header>
+
+<div id="service-list">
+
+    @if(form.hasGlobalErrors) {
+    <div class="alert alert-error error">
+        <a class="close" data-dismiss="alert">×</a>
+        <ul>
+            @form.globalErrors.map { error =>
+            <li>@error.format</li>
+            }
+        </ul>
+    </div>
+    }
+
+    <div class="board">
+        <div class="board__body">
+
+            @helper.form(
+            action = uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterServiceController.step2aPost
+            , 'class -> "form-inline"
+            , 'id -> "shutter-service-form"
+            , 'style -> "padding-left: 20px; padding-right: 20px"
+            ) {
+
+            @CSRF.formField
+
+            <div class="panel @if(step1Out.env == Environment.Production) {panel-danger} else {panel-warning}">
+                <div class="panel-heading">
+                    <span class="glyphicon glyphicon-warning-sign"></span>
+                    You are about to <b>Shutter</b> the following services in <b>@step1Out.env</b>:
+                </div>
+                <div class="panel-body">
+                    <ul style="list-style: disc;">
+                        @step1Out.serviceNames.map { serviceName =>
+                        <li>@serviceName</li>
+                        }
+                    </ul>
+                </div>
+            </div>
+
+            @if(frontendRouteWarnings.nonEmpty) {
+            <div class="row">
+                <div class="col-sm-12">
+                    <div class="panel panel-warning">
+                        <div class="panel-heading"><span class="glyphicon glyphicon-warning-sign"></span>
+                            There were some (@{frontendRouteWarnings.map(_.warnings.size).sum}) warnings found with the Frontend Routes.
+                        </div>
+                        <div class="panel-body">
+                            Please review, you can still continue to shutter.
+                            <br/><br/>
+                            <table class="table table-bordered">
+                                <thead>
+                                <tr>
+                                    <td>Service</td>
+                                    <td>Warning</td>
+                                    <td>Description</td>
+                                    <td>Consequence</td>
+                                </tr>
+                                </thead>
+                                @frontendRouteWarnings.map { frw =>
+                                @frw.warnings.map { warning =>
+                                <tr class="alert-warning">
+                                    <td>@frw.serviceName</td>
+                                    <td>@warning.name</td>
+                                    <td>@warning.message</td>
+                                    <td>@warning.consequence</td>
+                                </tr>
+                                }
+                                }
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            }
+
+            <div class="row">
+                <div class="col-sm-12">
+                    <div class="panel panel-warning">
+                        <div class="panel-heading">
+                            <span class="glyphicon glyphicon-warning-sign"></span>
+                            Please confirm you have checked the above frontend route warnings:
+                        </div>
+                        <div class="panel-body">
+                            <input type="checkbox" id="confirm" name="confirm" value="true">
+                            <label for="confirm">I confirm</label>
+                        </div>
+
+                    </div>
+                    </td>
+                </div>
+
+            </div>
+
+            <div class="row">
+                <div class="col-sm-6">
+                    <a id="back-btn"
+                       href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterServiceController.step1Get(None, None)"
+                       class="btn btn-default">
+                        <span class="glyphicon glyphicon-chevron-left"></span>
+                        Back
+                    </a>
+                </div>
+                <div class="col-sm-6" style="text-align:right;">
+                    <button id="next-btn" class="btn btn-primary" type="submit">
+                        Next
+                        <span class="glyphicon glyphicon-chevron-right"></span>
+                    </button>
+                </div>
+            </div>
+            }
+        </div>
+    </div>
+
+</div>
+
+}

--- a/app/views/shuttering/shutterService/Page2a.scala.html
+++ b/app/views/shuttering/shutterService/Page2a.scala.html
@@ -18,6 +18,7 @@
 @import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, ShutterStatusValue, ShutterState}
 @import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2aForm, ServiceAndRouteWarnings}
 @import helper._
+@import partials.form_warnings
 
 @this(viewMessages: ViewMessages)
 
@@ -36,16 +37,7 @@
 
 <div id="service-list">
 
-    @if(form.hasGlobalErrors) {
-    <div class="alert alert-error error">
-        <a class="close" data-dismiss="alert">×</a>
-        <ul>
-            @form.globalErrors.map { error =>
-            <li>@error.format</li>
-            }
-        </ul>
-    </div>
-    }
+    @form_warnings(form)
 
     <div class="board">
         <div class="board__body">

--- a/app/views/shuttering/shutterService/Page2b.scala.html
+++ b/app/views/shuttering/shutterService/Page2b.scala.html
@@ -16,13 +16,13 @@
 
 @import uk.gov.hmrc.cataloguefrontend.ViewMessages
 @import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, OutagePage, OutagePageStatus, ShutterStatusValue, ShutterState}
-@import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2Form}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2bForm}
 @import helper._
 @import partials.form_warnings
 
 @this(viewMessages: ViewMessages)
 
-@( form                  : Form[Step2Form]
+@( form                  : Form[Step2bForm]
  , step1Out              : Step1Out
  , requiresOutageMessage : Boolean
  , outageMessageSrc      : Option[OutagePage]
@@ -47,7 +47,7 @@
       <div class="board__body">
 
         @helper.form(
-            action =  uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterServiceController.step2Post
+            action =  uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterServiceController.step2bPost
           , 'class -> "form-inline"
           , 'id    -> "shutter-service-form"
           , 'style -> "padding-left: 20px; padding-right: 20px"

--- a/app/views/shuttering/shutterService/Page3.scala.html
+++ b/app/views/shuttering/shutterService/Page3.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.cataloguefrontend.ViewMessages
 @import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, ShutterStatusValue, ShutterServiceController, ShutterState}
-@import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2Out, Step3Form}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2bOut, Step3Form}
 @import uk.gov.hmrc.cataloguefrontend.connector.SlugInfoFlag
 @import helper._
 @import partials.form_warnings
@@ -25,7 +25,7 @@
 
 @( form                 : Form[Step3Form]
  , step1Out             : Step1Out
- , step2Out             : Step2Out
+ , step2Out             : Step2bOut
  , back                 : Call
  )(implicit request         : Request[_]
           , messagesProvider: MessagesProvider

--- a/app/views/shuttering/shutterService/Page3.scala.html
+++ b/app/views/shuttering/shutterService/Page3.scala.html
@@ -33,7 +33,7 @@
 @standard_layout(s"Shutter Service") {
 
   <header>
-    <h1>Shutter Service</h1>
+    <h1>Shutter Service: Confirm</h1>
   </header>
 
   <div>

--- a/app/views/shuttering/shutterService/Page3.scala.html
+++ b/app/views/shuttering/shutterService/Page3.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.{Step1Out, Step2Out, Step3Form}
 @import uk.gov.hmrc.cataloguefrontend.connector.SlugInfoFlag
 @import helper._
+@import partials.form_warnings
 
 @this(viewMessages: ViewMessages)
 
@@ -38,17 +39,7 @@
 
   <div>
 
-    @if(form.hasGlobalErrors) {
-      <div class="alert alert-error error">
-        <a class="close" data-dismiss="alert">×</a>
-        <ul>
-          @form.globalErrors.map { error =>
-            <li>@error.format</li>
-          }
-        </ul>
-      </div>
-    }
-
+    @form_warnings(form)
 
     <div class="board">
       <div class="board__body">

--- a/app/views/shuttering/shutterService/Page4.scala.html
+++ b/app/views/shuttering/shutterService/Page4.scala.html
@@ -18,6 +18,7 @@
 @import uk.gov.hmrc.cataloguefrontend.shuttering.{ShutterStatusValue, ShutterServiceController, ShutterState}
 @import uk.gov.hmrc.cataloguefrontend.connector.SlugInfoFlag
 @import helper._
+@import partials.form_warnings
 
 @this(viewMessages: ViewMessages)
 
@@ -29,7 +30,7 @@
 @standard_layout(s"Shutter Service") {
 
   <header>
-    <h1>Shutter Service</h1>
+    <h1>Shutter Service: Confirmation</h1>
   </header>
 
   <div id="service-list">

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -47,6 +47,7 @@ GET        /jdkexplorer                                 uk.gov.hmrc.cataloguefro
 GET        /bobbyrules                                  uk.gov.hmrc.cataloguefrontend.BobbyExplorerController.list()
 
 GET        /shuttering-overview/:env                    uk.gov.hmrc.cataloguefrontend.shuttering.ShutterController.allStates(env: String)
+GET        /frontend-route-warnings/:env/:serviceName   uk.gov.hmrc.cataloguefrontend.shuttering.ShutterController.frontendRouteWarnings(env: String, serviceName: String)
 
 GET        /shuttering/1                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step1Get(env: Option[String], serviceName: Option[String])
 POST       /shuttering/1                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step1Post

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -51,6 +51,8 @@ GET        /frontend-route-warnings/:env/:serviceName   uk.gov.hmrc.cataloguefro
 
 GET        /shuttering/1                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step1Get(env: Option[String], serviceName: Option[String])
 POST       /shuttering/1                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step1Post
+GET        /shuttering/2a                               uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2aGet
+POST       /shuttering/2a                               uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2aPost
 GET        /shuttering/2                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2Get
 POST       /shuttering/2                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2Post
 GET        /shuttering/3                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step3Get

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -53,8 +53,8 @@ GET        /shuttering/1                                uk.gov.hmrc.cataloguefro
 POST       /shuttering/1                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step1Post
 GET        /shuttering/2a                               uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2aGet
 POST       /shuttering/2a                               uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2aPost
-GET        /shuttering/2                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2Get
-POST       /shuttering/2                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2Post
+GET        /shuttering/2b                               uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2bGet
+POST       /shuttering/2b                               uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step2bPost
 GET        /shuttering/3                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step3Get
 POST       /shuttering/3                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step3Post
 GET        /shuttering/4                                uk.gov.hmrc.cataloguefrontend.shuttering.ShutterServiceController.step4Get

--- a/test/uk/gov/hmrc/cataloguefrontend/FrontendRouteWarningsPageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/FrontendRouteWarningsPageSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend
+
+import com.github.tomakehurst.wiremock.http.RequestMethod._
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws._
+import uk.gov.hmrc.play.test.UnitSpec
+
+class FrontendRouteWarningsPageSpec extends UnitSpec with GuiceOneServerPerSuite with WireMockEndpoints {
+
+  override def fakeApplication: Application = new GuiceApplicationBuilder()
+    .configure(
+      "microservice.services.shutter-api.port"          -> endpointPort,
+      "microservice.services.shutter-api.host"          -> host
+    )
+    .build()
+
+  private[this] lazy val ws = app.injector.instanceOf[WSClient]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    serviceEndpoint(GET, "/shutter-api/frontend-route-warnings/abc-frontend/development", willRespondWith = (200, Some(emptyJson)))
+    serviceEndpoint(GET, "/shutter-api/frontend-route-warnings/abc-frontend/qa", willRespondWith = (200, Some(emptyJson)))
+    serviceEndpoint(GET, "/shutter-api/frontend-route-warnings/abc-frontend/staging", willRespondWith = (200, Some(emptyJson)))
+    serviceEndpoint(GET, "/shutter-api/frontend-route-warnings/abc-frontend/externalTest", willRespondWith = (200, Some(emptyJson)))
+    serviceEndpoint(GET, "/shutter-api/frontend-route-warnings/abc-frontend/production", willRespondWith = (200, Some(emptyJson)))
+  }
+
+  "The frontend route warnings page" should {
+    "defaults to production if a bad environment is specified" in {
+      val response = await(ws.url(s"http://localhost:$port/frontend-route-warnings/something/abc-frontend").get)
+      response.status shouldBe 200
+      response.body.contains("""<li id="tab-production" class="navbar-item active">""") shouldBe true
+      response.body.contains("""There are no frontend-route warnings for this service in this environment""") shouldBe true
+    }
+    "shows the table with route warnings" in {
+      serviceEndpoint(GET, "/shutter-api/frontend-route-warnings/abc-frontend/development", willRespondWith = (200, Some(abcWarnings)))
+
+      val response = await(ws.url(s"http://localhost:$port/frontend-route-warnings/development/abc-frontend").get)
+      response.status shouldBe 200
+      response.body.contains("""<li id="tab-development" class="navbar-item active">""") shouldBe true
+      response.body.contains("""LegacyErrorPageMisconfigured""") shouldBe true
+    }
+  }
+
+  val emptyJson = "[]"
+
+  val abcWarnings =
+    """
+      |[
+      |{
+      |"name": "LegacyErrorPageMisconfigured",
+      |"message": "The legacy error_page configured '/shutter/abc/index.html' does not match the format '/shutter/abc-frontend/index.html'",
+      |"consequence": "You will mostly likely get a 404 when shuttered as the error_page pointed to will not exist",
+      |"ruleConfigurationURL": "conf/config.conf#L4602"
+      |}
+      |]
+      |""".stripMargin
+
+}


### PR DESCRIPTION
1. Add page at /frontend-route-warnings/:env/:service for showing all of the frontend-route warnings for a service retrieved from the `shutter-api`
1. Split the `/shuttering/2` page in the shutter service flow in two, `/shuttering/2a` and `/shuttering/2b`. The new `2a` page displays any frontend route warnings and requires the user to confirm they have acknowledged them before they can continue. The flow then continues to `2b` which is the outage-page step as before.
1. Page `2a` is skipped if there are no warnings for any of the services being shuttered (or if being unshuttered)