### PR TITLE
BDOG-447: Basic What's Running Where

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnector.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.whatsrunningwhere
+
+import javax.inject.{Inject, Singleton}
+import play.api.Logger
+import WhatsRunningWhere._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+
+@Singleton
+class ReleasesConnector @Inject()(http: HttpClient,
+                                  servicesConfig: ServicesConfig)(implicit ec: ExecutionContext) {
+
+  private val serviceUrl: String = servicesConfig.baseUrl("releases-api")
+
+  def releases(profileName: Option[ProfileName])(implicit hc: HeaderCarrier): Future[Seq[WhatsRunningWhere]] = {
+    val baseUrl = s"$serviceUrl/releases-api/whats-running-where"
+    http
+      .GET[Seq[WhatsRunningWhere]](profileName.fold(baseUrl)(profileName => s"$baseUrl?profileName=${profileName.asString}"))
+      .recover {
+        case NonFatal(ex) =>
+          Logger.error(s"An error occurred when connecting to $serviceUrl: ${ex.getMessage}", ex)
+          Seq.empty
+      }
+  }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/WhatsRunningWhereController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/WhatsRunningWhereController.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.whatsrunningwhere
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.WhatsRunningWherePage
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class WhatsRunningWhereController @Inject()(
+    releasesConnector: ReleasesConnector
+  , page: WhatsRunningWherePage
+  , mcc: MessagesControllerComponents
+  )(implicit val ec: ExecutionContext
+  ) extends FrontendController(mcc){
+
+  def landing(profileName: Option[String]): Action[AnyContent] =
+    Action.async { implicit request =>
+
+      for {
+        releases <- releasesConnector.releases(profileName.map(ProfileName.apply))
+      } yield {
+        val environments = releases.flatMap(_.versions.map(_.environment)).distinct
+        Ok(page(environments, releases))
+      }
+    }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/model.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/model.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.whatsrunningwhere
+
+import java.time.LocalDateTime
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import JsonCodecs._
+
+case class WhatsRunningWhere(applicationName: ApplicationName,
+                             versions: List[WhatsRunningWhereVersion])
+
+object WhatsRunningWhere {
+  implicit val whatsRunningWhereFormat: Reads[WhatsRunningWhere] = (
+    (__ \ "applicationName").read[ApplicationName] and
+    (__ \ "versions").read[List[WhatsRunningWhereVersion]]
+  )(WhatsRunningWhere.apply _)
+}
+
+case class WhatsRunningWhereVersion(environment: Environment,
+                                    versionNumber: VersionNumber,
+                                    lastSeen: TimeSeen)
+
+object WhatsRunningWhereVersion {
+  implicit val versionFormat: Reads[WhatsRunningWhereVersion] = (
+    (__ \ "environment").read[Environment] and
+    (__ \ "versionNumber").read[VersionNumber] and
+    (__ \ "lastSeen").read[TimeSeen]
+  )(WhatsRunningWhereVersion.apply _)
+}
+
+object JsonCodecs {
+  def format[A, B](f: A => B, g: B => A)(implicit fa: Format[A]): Format[B] = fa.inmap(f, g)
+
+  implicit val applicationNameFormat: Format[ApplicationName] = format(ApplicationName.apply, unlift(ApplicationName.unapply))
+  implicit val versionNumberFormat: Format[VersionNumber] = format(VersionNumber.apply, unlift(VersionNumber.unapply))
+  implicit val environmentFormat: Format[Environment] = format(Environment.apply, unlift(Environment.unapply))
+  implicit val timeSeenFormat: Format[TimeSeen] = format(TimeSeen.apply, unlift(TimeSeen.unapply))
+}
+
+case class TimeSeen(time: LocalDateTime)
+
+case class ApplicationName(asString: String) extends AnyVal
+
+case class Environment(asString: String) extends AnyVal
+
+case class ProfileName(asString: String) extends AnyVal
+
+case class VersionNumber(asString: String) extends AnyVal
+

--- a/app/views/WhatsRunningWherePage.scala.html
+++ b/app/views/WhatsRunningWherePage.scala.html
@@ -1,0 +1,44 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.ViewMessages
+@import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.Environment
+@import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhere
+
+@this(viewMessages: ViewMessages)
+@(environments: Seq[Environment], whatsRunning: Seq[WhatsRunningWhere])(implicit request: Request[_])
+@standard_layout("What's Running Where?", "whats-running") {
+  <table id="whats-running-where" class="table table-striped">
+   <thead>
+    <th>App name</th>
+    @environments.map { env =>
+      <th>@env.asString</th>
+    }
+   </thead>
+   @whatsRunning.zipWithIndex.map { case (wrw, i) =>
+     <tr role="row" id="row@{i}_name">
+      <td>@{wrw.applicationName.asString}</td>
+      @environments.map { env =>
+        @wrw.versions.find(_.environment == env).map { version =>
+          <td>@version.versionNumber.asString</td>
+        }.getOrElse {
+          <td></td>
+        }
+      }
+     </tr>
+   }
+  </table>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -63,3 +63,5 @@ GET        /shuttering/:shutterType/:env                uk.gov.hmrc.cataloguefro
 
 GET        /shutter-events                              uk.gov.hmrc.cataloguefrontend.shuttering.ShutterEventsController.shutterEvents
 GET        /shutter-events/list                         uk.gov.hmrc.cataloguefrontend.shuttering.ShutterEventsController.shutterEventsList(env: ShutteringEnvironment, serviceName: Option[String] ?= None)
+
+GET        /whats-running-where                         uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereController.landing(profileName: Option[String])

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -184,6 +184,11 @@ microservice {
       host = "localhost"
       port = 7077
     }
+
+    releases-api {
+      host = "localhost"
+      port = 8008
+    }
   }
 }
 

--- a/test/uk/gov/hmrc/cataloguefrontend/WhatsRunningWhereSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/WhatsRunningWhereSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend
+
+import com.github.tomakehurst.wiremock.http.RequestMethod._
+import org.scalatest._
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws._
+import uk.gov.hmrc.play.test.UnitSpec
+
+class WhatsRunningWhereSpec extends UnitSpec with BeforeAndAfter with GuiceOneServerPerSuite with WireMockEndpoints {
+
+  override def fakeApplication: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        "microservice.services.releases-api.host"  -> host,
+        "microservice.services.releases-api.port"  -> endpointPort,
+        "play.ws.ssl.loose.acceptAnyCertificate"             -> true,
+        "play.http.requestHandler"                           -> "play.api.http.DefaultHttpRequestHandler",
+        "metrics.jvm"                                        -> false
+      )
+      .build()
+
+  private[this] lazy val WS = app.injector.instanceOf[WSClient]
+
+  "What's running where page" should {
+
+    "show a list of applications, environments and version numbers" in {
+      serviceEndpoint(
+        GET,
+        "/releases-api/whats-running-where",
+        willRespondWith = (
+          200,
+          Some(
+            """[
+              |  {
+              |    "applicationName": "api-definition",
+              |    "versions": [
+              |      {
+              |        "environment": "integration-AWS-London",
+              |        "versionNumber": "1.57.0",
+              |        "lastSeen": "2019-05-29T14:09:48"
+              |      }
+              |    ]
+              |  },
+              |  {
+              |    "applicationName": "api-documentation",
+              |    "versions": [
+              |      {
+              |        "environment": "integration-AWS-London",
+              |        "versionNumber": "0.44.0",
+              |        "lastSeen": "2019-05-29T14:09:46"
+              |      }
+              |    ]
+              |  }
+              |]""".stripMargin))
+      )
+
+      val response = await(WS.url(s"http://localhost:$port/whats-running-where").get)
+
+      response.status shouldBe 200
+
+      response.body   should include("api-definition")
+      response.body   should include("1.57.0")
+
+      response.body   should include("api-documentation")
+      response.body   should include("0.44.0")
+
+      response.body   should include("integration-AWS-London")
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/ReleasesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/ReleasesConnectorSpec.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.connector
+
+import java.time.LocalDateTime
+
+import com.github.tomakehurst.wiremock.http.RequestMethod._
+import org.scalatest._
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeHeaders
+import uk.gov.hmrc.cataloguefrontend.connector.model._
+import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.{ApplicationName, Environment, ProfileName, ReleasesConnector, TimeSeen, VersionNumber, WhatsRunningWhere, WhatsRunningWhereVersion}
+import uk.gov.hmrc.play.HeaderCarrierConverter
+import uk.gov.hmrc.play.test.UnitSpec
+
+class ReleasesConnectorSpec
+    extends UnitSpec
+    with GuiceOneServerPerSuite
+    with WireMockEndpoints
+    with EitherValues {
+
+  override def fakeApplication: Application = new GuiceApplicationBuilder()
+    .disable(classOf[com.kenshoo.play.metrics.PlayModule])
+    .configure(Map(
+      "microservice.services.releases-api.port" -> endpointPort,
+      "microservice.services.releases-api.host" -> host,
+      "play.http.requestHandler"                -> "play.api.http.DefaultHttpRequestHandler",
+      "metrics.jvm"                             -> false
+    ))
+    .build()
+
+  private lazy val releasesConnector = app.injector.instanceOf[ReleasesConnector]
+
+  "releases" should {
+
+    "return all releases if profile not supplied" in {
+      serviceEndpoint(
+        GET,
+        "/releases-api/whats-running-where",
+        willRespondWith = (
+          200,
+          Some(
+            """[
+              |  {
+              |    "applicationName": "api-definition",
+              |    "versions": [
+              |      {
+              |        "environment": "integration-AWS-London",
+              |        "versionNumber": "1.57.0",
+              |        "lastSeen": "2019-05-29T14:09:48"
+              |      }
+              |    ]
+              |  },
+              |  {
+              |    "applicationName": "api-documentation",
+              |    "versions": [
+              |      {
+              |        "environment": "integration-AWS-London",
+              |        "versionNumber": "0.44.0",
+              |        "lastSeen": "2019-05-29T14:09:46"
+              |      }
+              |    ]
+              |  }
+              |]""".stripMargin)))
+
+      val response = await(
+        releasesConnector.releases(profileName = None)(HeaderCarrierConverter.fromHeadersAndSession(FakeHeaders()))
+      )
+
+      response should contain theSameElementsAs Seq(
+        WhatsRunningWhere(
+          ApplicationName("api-definition"),
+          List(
+            WhatsRunningWhereVersion(
+              Environment("integration-AWS-London"),
+              VersionNumber("1.57.0"),
+              lastSeen = TimeSeen(LocalDateTime.parse("2019-05-29T14:09:48")))
+          )
+        ),
+        WhatsRunningWhere(
+          ApplicationName("api-documentation"),
+          List(
+            WhatsRunningWhereVersion(
+              Environment("integration-AWS-London"),
+              VersionNumber("0.44.0"),
+              lastSeen = TimeSeen(LocalDateTime.parse("2019-05-29T14:09:46")))
+          )
+        )
+      )
+    }
+
+    "return all releases for given profileName" in {
+      val profileName = ProfileName("profile1")
+
+      serviceEndpoint(
+        GET,
+        s"/releases-api/whats-running-where",
+        queryParameters = Seq(("profileName", profileName.asString)),
+        willRespondWith = (
+          200,
+          Some(
+            """[
+              |  {
+              |    "applicationName": "api-definition",
+              |    "versions": [
+              |      {
+              |        "environment": "integration-AWS-London",
+              |        "versionNumber": "1.57.0",
+              |        "lastSeen": "2019-05-29T14:09:48"
+              |      }
+              |    ]
+              |  }
+              |]""".stripMargin)))
+
+      val response = await(
+        releasesConnector.releases(profileName = Some(profileName))(HeaderCarrierConverter.fromHeadersAndSession(FakeHeaders()))
+      )
+
+      response should contain theSameElementsAs Seq(
+        WhatsRunningWhere(
+          ApplicationName("api-definition"),
+          List(
+            WhatsRunningWhereVersion(
+              Environment("integration-AWS-London"),
+              VersionNumber("1.57.0"),
+              lastSeen = TimeSeen(LocalDateTime.parse("2019-05-29T14:09:48")))
+          )
+        )
+      )
+    }
+
+    "return empty upon error" in {
+      serviceEndpoint(
+        GET,
+        s"/releases-api/whats-running-where",
+        willRespondWith = (500, Some("errors!")))
+
+      val response = await(
+        releasesConnector.releases(profileName = None)(HeaderCarrierConverter.fromHeadersAndSession(FakeHeaders()))
+      )
+
+      response shouldBe Seq.empty
+    }
+  }
+}


### PR DESCRIPTION
Porting the What's Running Where from the old releases app to the
Catalogue. This is a first commit; more will come to address all the
points in the ticket. For instance, filtering is only available via
query params, and there is no link to the page on the menu yet.

I have attached a screenshot of it to the JIRA.