### PR TITLE
BDOG-446: service page - environments as tabs with version-specific dependencies

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/ServiceInfoView.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/ServiceInfoView.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend
+
+import uk.gov.hmrc.cataloguefrontend.connector.TargetEnvironment
+import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependencies, Dependency}
+import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterState
+import uk.gov.hmrc.cataloguefrontend.shuttering.{ShutterStatusValue, Environment => ShutteringEnvironment}
+
+object ServiceInfoView {
+  def isShuttered(withShutterState: Map[ShutteringEnvironment, ShutterState])(inEnvironment: TargetEnvironment): Boolean =
+    TargetEnvironment.toShutteringEnvironment(inEnvironment).flatMap(withShutterState.get).exists {
+      _.status.value == ShutterStatusValue.Shuttered
+    }
+
+  def libraryDependenciesOf(optDependencies: Option[Dependencies]): Seq[Dependency] =
+    optDependencies.map(_.libraryDependencies).getOrElse(Seq.empty)
+
+  def slugDependencies(withDeployments: Map[String, Seq[DeploymentVO]], withDependencies: Map[String, Seq[Dependency]])
+                      (forEnvironment: TargetEnvironment): Seq[Dependency] =
+    lookupDeployment(withDeployments)(forEnvironment).flatMap { deployment =>
+      withDependencies.get(deployment.version)
+    }.getOrElse(Seq.empty)
+
+  def deploymentVersion(withDeployments: Map[String, Seq[DeploymentVO]])
+                       (forEnvironment: TargetEnvironment): Option[String] =
+    lookupDeployment(withDeployments)(forEnvironment).map(_.version)
+
+  private def lookupDeployment(deploymentsByEnvironmentName: Map[String, Seq[DeploymentVO]])
+                              (forEnvironment: TargetEnvironment): Option[DeploymentVO] =
+    deploymentsByEnvironmentName.get(forEnvironment.name.toLowerCase).flatMap {
+      _.headOption
+    }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/model/Dependencies.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/model/Dependencies.scala
@@ -177,20 +177,18 @@ case class BobbyRuleViolation(reason: String, range: BobbyVersionRange, from: Lo
 
 
 object Dependencies {
-  val reads: Reads[Dependencies] = {
-    implicit val dtr = RestFormats.dateTimeFormats
-    implicit val bvf = BobbyVersionRange.format
-    implicit val brvr =
-      ( (__ \ "reason" ).read[String]
-      ~ (__ \ "range"  ).read[BobbyVersionRange]
-      ~ (__ \ "from"   ).read[LocalDate]
-      )(BobbyRuleViolation.apply _)
+  object Implicits {
+    private implicit val vf = Version.format
+    private implicit val dtr = RestFormats.dateTimeFormats
+    private implicit val bvf = BobbyVersionRange.format
+    private implicit val brvr =
+      ((__ \ "reason").read[String]
+        ~ (__ \ "range").read[BobbyVersionRange]
+        ~ (__ \ "from").read[LocalDate]
+        ) (BobbyRuleViolation.apply _)
 
-    implicit val osf = {
-      implicit val vf = Version.format
-      Json.reads[Dependency]
-    }
-    Json.reads[Dependencies]
+    implicit val readsDependency: Reads[Dependency] = Json.reads[Dependency]
+    implicit val reads: Reads[Dependencies] = Json.reads[Dependencies]
   }
 
   def collectViolations(dependenciesSeq: Seq[Dependencies], f: Dependency => Seq[BobbyRuleViolation]): Seq[(String, BobbyRuleViolation)] =

--- a/app/views/ServiceConfigPage.scala.html
+++ b/app/views/ServiceConfigPage.scala.html
@@ -14,12 +14,11 @@
  * limitations under the License.
  *@
 
-@import partials.DependenciesPartial
 @import uk.gov.hmrc.cataloguefrontend.ViewMessages
 @import uk.gov.hmrc.cataloguefrontend.service.ConfigService._
 @import scala.collection.immutable.ListMap
 
-@this(dependenciesPartial: DependenciesPartial, viewMessages: ViewMessages)
+@this(viewMessages: ViewMessages)
 @(serviceName: String, configByKey: ConfigByKey)(implicit messages: Messages, request: Request[_])
 <html>
     <head>

--- a/app/views/ServiceInfoPage.scala.html
+++ b/app/views/ServiceInfoPage.scala.html
@@ -14,25 +14,21 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.cataloguefrontend.CatalogueFrontendSwitches
-@import uk.gov.hmrc.cataloguefrontend.connector.RepositoryDetails
-@import uk.gov.hmrc.cataloguefrontend.ViewMessages
-@import play.twirl.api.Html
 @import java.time.LocalDateTime
-@import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.ServiceRoutes
-@import uk.gov.hmrc.cataloguefrontend.DeploymentVO
-@import uk.gov.hmrc.cataloguefrontend.connector.model.Dependencies
-@import uk.gov.hmrc.cataloguefrontend.connector.TargetEnvironment
+@import partials.{BuildToolsPartial, DependenciesByEnvironmentPartial}
+@import play.twirl.api.Html
+@import uk.gov.hmrc.cataloguefrontend.connector.RepositoryDetails
+@import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependencies, Dependency}
+@import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.{EnvironmentRoute, ServiceRoutes}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment => ShutteringEnvironment, ShutterState}
+@import uk.gov.hmrc.cataloguefrontend.{DeploymentVO, ServiceInfoView, ViewMessages}
 @import views.partials.githubBadgeType
-@import partials.DependenciesPartial
-@import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.EnvironmentRoute
-@import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment => ShutteringEnvironment, ShutterState, ShutterStatus, ShutterStatusValue}
-@import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterStatus._
 
-@this(dependenciesPartial: DependenciesPartial, viewMessages: ViewMessages)
+@this(dependenciesByEnvironmentPartial: DependenciesByEnvironmentPartial, buildToolsPartial: BuildToolsPartial, viewMessages: ViewMessages)
 
 @(service: RepositoryDetails,
-  optDependencies: Option[Dependencies],
+  optLatestDependencies: Option[Dependencies],
+  dependenciesByVersion: Map[String, Seq[Dependency]],
   repositoryCreationDate: LocalDateTime,
   deploymentsByEnvironmentName: Map[String, Seq[DeploymentVO]],
   linkToLeakDetection: Option[String],
@@ -40,7 +36,6 @@
   serviceRoutes: ServiceRoutes,
   shutterState: Map[ShutteringEnvironment, ShutterState]
 )(implicit messages: Messages, request: Request[_])
-
 
 
 @standard_layout(service.name, "services") {
@@ -53,8 +48,8 @@
     </header>
 
     @partials.leak_detection_banner(linkToLeakDetection)
-    @partials.bobby_active_violations_banner(optDependencies.map(_.toSeq).getOrElse(Seq.empty))
-    @partials.bobby_pending_violations_banner(optDependencies.map(_.toSeq).getOrElse(Seq.empty))
+    @partials.bobby_active_violations_banner(optLatestDependencies.map(_.toSeq).getOrElse(Seq.empty))
+    @partials.bobby_pending_violations_banner(optLatestDependencies.map(_.toSeq).getOrElse(Seq.empty))
 
     <section class="section-wrapper">
 
@@ -89,64 +84,21 @@
                 @partials.code_and_builds(service)
             </div>
         </div>
-        <div class="row">
-        @for((environment, idx) <- service.environments.get.zipWithIndex) {
-            <div id="@{environment.id}-environment" class="col-md-2">
-                <div class="board environment_board">
-                    @renderEnvironmentBoardHeading(deploymentsByEnvironmentName, shutterState, environment)
-                    <div class="board__body">
-                        <ul class="list list--minimal">
-                            @if(environment.services.isEmpty) {
-                                <li class="list-item">
-                                    Not deployed
-                                </li>
-                            } else {
-                                @for(tool <- environment.services) {
-                                    <li class="list-item"><a id="link-to-@{tool.id}" href="@{tool.url}" target="_blank">@{tool.displayName}<span class="glyphicon glyphicon-new-window"/></a></li>
-                                }
-                            }
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        }
-        </div>
+
+        @dependenciesByEnvironmentPartial(
+            service, optLatestDependencies, dependenciesByVersion, deploymentsByEnvironmentName, shutterState
+        )
+
         <div class="row">
             <div class="col-md-12">
-                @dependenciesPartial(optDependencies)
+                @buildToolsPartial(optLatestDependencies)
             </div>
         </div>
-        </div>
     </section>
+
     <div class="alert alert-success" role="alert" id="@service.name">
         <p>
         @Html(viewMessages.informationalText)
         </p>
     </div>
-}
-
-@renderEnvironmentBoardHeading(deploymentsByEnvironmentName: Map[String, Seq[DeploymentVO]], shutterState: Map[ShutteringEnvironment, ShutterState], environment: TargetEnvironment) = {
-    @if(TargetEnvironment.toShutteringEnvironment(environment)
-          .flatMap(shutterState.get)
-          .map(_.status.value == ShutterStatusValue.Shuttered)
-          .getOrElse(false)) {
-        <div class="board__heading environment shuttered_board">
-            <div class="shutter_label shuttered">shuttered</div>
-            <div class="environment-name"><h3 class="shuttered">@environment.name</h3></div>
-            @for(environmentDeployments <- deploymentsByEnvironmentName.get(environment.name.toLowerCase)) {
-                @for(environmentDeployment <- environmentDeployments) {
-                    <div class="service-version shuttered small" style="margin-top: 0.1em;">@environmentDeployment.version</div>
-                }
-            }
-        </div>
-    } else {
-        <div class="board__heading environment">
-            <div class="environment-name"><h3>@environment.name</h3></div>
-            @for(environmentDeployments <- deploymentsByEnvironmentName.get(environment.name.toLowerCase)) {
-                @for(environmentDeployment <- environmentDeployments) {
-                    <div class="service-version small" style="margin-top: 0.1em;">@environmentDeployment.version</div>
-                }
-            }
-        </div>
-    }
 }

--- a/app/views/partials/BuildToolsPartial.scala.html
+++ b/app/views/partials/BuildToolsPartial.scala.html
@@ -1,0 +1,56 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.ViewMessages
+@import uk.gov.hmrc.cataloguefrontend.connector.model._
+
+@this(viewMessages: ViewMessages)
+
+@(mayBeDependencies: Option[Dependencies])
+
+
+<div id="build_tools" class="board">
+    <h3 class="board__heading">Build Tools</h3>
+    <div class="board__body">
+        <div class="col-xs-8">
+            <ul class="list list--minimal list-group row">
+                @if(dependencyDataAvailable()) {
+                <li>
+                    <span class="col-xs-4"><label>Sbt plugins</label></span>
+                    <span class="col-xs-3"><label>Current Version</label></span>
+                    <span class="col-xs-3"><label>Latest Version</label></span>
+                    <span class="col-xs-2"><label>Violation</label></span>
+                </li>
+                @partials.dependency_section(mayBeDependencies.get.sbtPluginsDependencies)
+
+                <li><span class="col-xs-12">&nbsp;</span></li>
+                <li><span class="col-xs-12"><label>Other</label></span></li>
+                @partials.dependency_section(mayBeDependencies.get.otherDependencies)
+                } else {
+                <li>No Build Tools available</li>
+                }
+            </ul>
+        </div>
+        @if(dependencyDataAvailable()) {
+            @partials.dependency_legend(includeUpToDate = true)
+        }
+    </div>
+
+    @dependencyDataAvailable() = @{
+        mayBeDependencies.isDefined &&
+        (mayBeDependencies.get.sbtPluginsDependencies.nonEmpty || mayBeDependencies.get.otherDependencies.nonEmpty)
+    }
+</div>

--- a/app/views/partials/DependenciesByEnvironmentPartial.scala.html
+++ b/app/views/partials/DependenciesByEnvironmentPartial.scala.html
@@ -1,0 +1,133 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import partials.ServiceDependenciesPartial
+@import uk.gov.hmrc.cataloguefrontend.connector.{RepositoryDetails, TargetEnvironment}
+@import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependencies, Dependency}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment => ShutteringEnvironment, ShutterState}
+@import uk.gov.hmrc.cataloguefrontend.{DeploymentVO, ServiceInfoView, ViewMessages}
+
+
+@this(dependenciesPartial: ServiceDependenciesPartial, viewMessages: ViewMessages)
+
+@(service: RepositoryDetails,
+  optLatestDependencies: Option[Dependencies],
+  dependenciesByVersion: Map[String, Seq[Dependency]],
+  deploymentsByEnvironmentName: Map[String, Seq[DeploymentVO]],
+  shutterState: Map[ShutteringEnvironment, ShutterState]
+)
+
+
+<ul id="environmentTabs" class="nav nav-tabs" role="tablist">
+    <!-- we hard-code 'latest' as it is not a deployment 'environment' -->
+    <li class="nav-item active">
+        <a id="latest-tab" class="nav-link" data-toggle="tab" href="#latest-pane" role="tab" aria-controls="latest" aria-selected="true">
+            <div class="board">
+                <div class="board__heading">
+                    <h4 class="environment-name">Latest</h4>
+                    @renderVersion(None)
+                </div>
+                <div class="board__body">
+                    @renderShutterStatusBadge(false)
+                </div>
+            </div>
+        </a>
+    </li>
+
+    @for(environment <- service.environments.getOrElse(Seq.empty)) {
+    <li class="nav-item">
+        <a id="@{environment.id}-tab" class="nav-link" data-toggle="tab" href="#@{environment.id}-pane" role="tab" aria-controls="@environment.id" aria-selected="false">
+            <div class="board">
+                <div class="board__heading">
+                    <h4 class="environment-name">@environment.name</h4>
+                    @renderVersion(ServiceInfoView.deploymentVersion(withDeployments = deploymentsByEnvironmentName)(forEnvironment = environment))
+                </div>
+                <div class="board__body">
+                    @renderShutterStatusBadge(ServiceInfoView.isShuttered(withShutterState = shutterState)(inEnvironment = environment))
+                </div>
+            </div>
+        </a>
+    </li>
+    }
+</ul>
+
+<div id="environmentPanes" class="tab-content environment-panes">
+    <!-- we hard-code 'latest' as it is not a deployment 'environment' -->
+    <div id="latest-pane" class="tab-pane active" role="tabpanel" aria-labelledby="latest-tab">
+        <!-- no telemetry section for 'latest' -->
+        <div class="row">
+            <div class="col-md-12">
+                @dependenciesPartial(ServiceInfoView.libraryDependenciesOf(optLatestDependencies), "platform-dependencies-latest")
+            </div>
+        </div>
+    </div>
+
+    @for(environment <- service.environments.getOrElse(Seq.empty)) {
+    <div id="@{environment.id}-pane" class="tab-pane" role="tabpanel" aria-labelledby="@{environment.id}-tab">
+        <div class="row">
+            <div class="col-md-12">
+                <div id="@{environment.id}-telemetry" class="board">
+                    <h3 class="board__heading">Telemetry</h3>
+                    <div class="board__body">
+                        <ul class="list list--minimal">
+                            @if(environment.services.isEmpty) {
+                            <li class="list-item">
+                                Not deployed
+                            </li>
+                            } else {
+                            @for(tool <- environment.services) {
+                            <li class="list-item col-xs-4">
+                                <a id="link-to-@{tool.id}-@{environment.id}" href="@{tool.url}" target="_blank">
+                                    @{tool.displayName}<span class="glyphicon glyphicon-new-window"></span>
+                                </a>
+                            </li>
+                            }
+                            }
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-12">
+                @dependenciesPartial(ServiceInfoView.slugDependencies(
+                    withDeployments = deploymentsByEnvironmentName,
+                    withDependencies = dependenciesByVersion)(forEnvironment = environment), s"platform-dependencies-${environment.id}"
+                )
+            </div>
+        </div>
+    </div>
+    }
+</div>
+
+@renderVersion(optVersion: Option[String]) = {
+    @if(optVersion.isDefined) {
+        <p class="small">@optVersion.get</p>
+    } else {
+        <!-- needed to ensure each tab nav-item has the same height -->
+        <p class="small">&nbsp;</p>
+    }
+}
+
+@renderShutterStatusBadge(isShuttered: Boolean) = {
+    @if(isShuttered) {
+        <div class="shutter-badge"></div>
+    } else {
+        <!-- needed to ensure each tab nav-item has the same height -->
+        <div class="noshutter-badge"></div>
+    }
+}

--- a/app/views/partials/ServiceDependenciesPartial.scala.html
+++ b/app/views/partials/ServiceDependenciesPartial.scala.html
@@ -1,0 +1,47 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.ViewMessages
+@import uk.gov.hmrc.cataloguefrontend.connector.model._
+
+@this(viewMessages: ViewMessages)
+
+@(dependencies: Seq[Dependency], rootId: String)
+
+
+<div id="@rootId" class="board">
+    <h3 class="board__heading">Platform Dependencies</h3>
+    <div class="board__body">
+    <div class="col-xs-8">
+            <ul class="list list--minimal list-group row">
+                @if(dependencies.nonEmpty) {
+                    <li>
+                        <span class="col-xs-4"><label>Libraries</label></span>
+                        <span class="col-xs-3"><label>Current Version</label></span>
+                        <span class="col-xs-3"><label>Latest Version</label></span>
+                        <span class="col-xs-2"><label>Violation</label></span>
+                    </li>
+                    @partials.dependency_section(dependencies)
+                } else {
+                    <li>No Library dependencies available</li>
+                }
+            </ul>
+        </div>
+        @if(dependencies.nonEmpty) {
+            @partials.dependency_legend(includeUpToDate = true)
+        }
+    </div>
+</div>

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -12283,7 +12283,6 @@ table.shutter-events {
 
 #environmentTabs li a .board .board__heading {
   border: none;
-  padding: 6px;
   padding-top: 2px;
   padding-bottom: 0px;
 }
@@ -12297,6 +12296,10 @@ table.shutter-events {
 }
 
 .nav-tabs > li.active > a > .board > .board__heading {
+  background-color: #f5f5f5;
+}
+
+.nav-tabs > li > a > .board > .board__heading {
   background: inherit;
 }
 
@@ -12306,6 +12309,10 @@ table.shutter-events {
   margin-bottom: 16px;
   border: 1px solid #ddd;
   border-top: none;
+}
+
+.environment-panes .board {
+  border: none;
 }
 
 .shutter-badge {

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -12141,23 +12141,6 @@ div.shutter_label {
     top: 0px;
 }
 
-.environment-name h3 {
-    margin: 5px 0px 0px 0px;
-}
-
-.environment-name h3.shuttered {
-    color: #fff;
-    display: inline-block;
-}
-
-div.service-version {
-    display: inline-block;
-    position: absolute;
-    bottom: 4px;
-    left: 13px;
-    margin: 0px;
-}
-
 p.shuttered:empty {
     display: none
 }
@@ -12286,4 +12269,60 @@ table.shutter-events {
 
 #shutter-events-form #serviceName {
   margin-bottom: 10px;
+}
+
+#environmentTabs li a {
+  padding: 2px;
+  padding-bottom: 0px;
+}
+
+#environmentTabs li a .board {
+  margin-bottom: 2px;
+  border: none;
+}
+
+#environmentTabs li a .board .board__heading {
+  border: none;
+  padding: 6px;
+  padding-top: 2px;
+  padding-bottom: 0px;
+}
+
+#environmentTabs li a .board .board__heading p {
+  margin-bottom: 0px;
+}
+
+#environmentTabs li a .board .board__body {
+  padding: 0px;
+}
+
+.nav-tabs > li.active > a > .board > .board__heading {
+  background: inherit;
+}
+
+.environment-panes {
+  padding: 16px;
+  padding-bottom: 0px;
+  margin-bottom: 16px;
+  border: 1px solid #ddd;
+  border-top: none;
+}
+
+.shutter-badge {
+  border-radius: 21%;
+  width: 15px;
+  height: 15px;
+  padding: 2px;
+  margin-top: 2px;
+  background: repeating-linear-gradient(-45deg, #6d6d6d, #6d6d6d 2px, #d0a039a3 3px, #d0a039a3 5px);
+  border: 1px solid #666;
+}
+
+.noshutter-badge {
+  border-radius: 21%;
+  width: 15px;
+  height: 15px;
+  padding: 2px;
+  margin-top: 2px;
+  border: none;
 }

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnectorSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cataloguefrontend.connector
 
 import com.github.tomakehurst.wiremock.http.RequestMethod._
+import org.apache.http.HttpStatus
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest._
@@ -24,6 +25,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
+import play.api.http.Status
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
@@ -321,6 +323,53 @@ class ServiceDependenciesConnectorSpec
         Seq(
           Dependency("sbt", Version("0.13.8"), Some(Version("0.13.15")))
         )
+    }
+  }
+
+  "GET curated slug dependencies" - {
+    "return a list of curated dependencies for a known slug" in new Setup {
+      val SlugName = "slug-name"
+      val SlugVersion = "slug-version"
+      serviceEndpoint(GET, url = s"/api/slug-dependencies/$SlugName/$SlugVersion",
+        willRespondWith = (Status.OK, Some(
+          """|[{
+             |  "name": "dep1",
+             |  "currentVersion": {"major": 1, "minor": 0, "patch": 0, "original": "1.0.0"},
+             |  "bobbyRuleViolations": [],
+             |  "isExternal": false
+             | },
+             | {"name": "dep2",
+             |  "currentVersion": {"major": 2, "minor": 0, "patch": 0, "original": "2.0.0"},
+             |  "latestVersion": {"major": 2, "minor": 1, "patch": 0, "original": "2.1.0"},
+             |  "bobbyRuleViolations": [],
+             |  "isExternal": false
+             | }]""".stripMargin)))
+
+      val response = serviceDependenciesConnector.getCuratedSlugDependencies(SlugName, SlugVersion).futureValue
+
+      response should contain theSameElementsAs Seq(
+        Dependency(name = "dep1", currentVersion = Version("1.0.0"), latestVersion = None),
+        Dependency(name = "dep2", currentVersion = Version("2.0.0"), latestVersion = Some(Version("2.1.0")))
+      )
+    }
+
+    "return an empty list of dependencies for an unknown slug" in new Setup {
+      val SlugName = "slug-name"
+      val SlugVersion = "slug-version"
+      serviceEndpoint(GET, url = s"/api/slug-dependencies/$SlugName/$SlugVersion",
+        willRespondWith = (Status.NOT_FOUND, None))
+
+      serviceDependenciesConnector.getCuratedSlugDependencies(SlugName, SlugVersion).futureValue shouldBe empty
+    }
+
+    "return an empty list of dependencies when a communication error occurs" in new Setup {
+      val mockedHttpClient = mock[HttpClient]
+      when(mockedHttpClient.GET(any())(any(), any(), any()))
+        .thenReturn(Future.failed(new RuntimeException("Boom!!")))
+
+      val connector = new ServiceDependenciesConnector(mockedHttpClient, mock[ServicesConfig])
+
+      connector.getCuratedSlugDependencies("slugName", "slugVersion").futureValue shouldBe empty
     }
   }
 

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnectorSpec.scala
@@ -17,7 +17,6 @@
 package uk.gov.hmrc.cataloguefrontend.connector
 
 import com.github.tomakehurst.wiremock.http.RequestMethod._
-import org.apache.http.HttpStatus
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest._
@@ -29,8 +28,8 @@ import play.api.http.Status
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
-import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependency, JDK, JRE, OpenJDK, Oracle, Version}
-import uk.gov.hmrc.cataloguefrontend.service.{DependenciesService, ServiceDependencies}
+import uk.gov.hmrc.cataloguefrontend.connector.model._
+import uk.gov.hmrc.cataloguefrontend.service.ServiceDependencies
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.http.HttpClient


### PR DESCRIPTION
Add a tabbed section to the service page, and move library dependencies & service urls (such as Kibana / Grafana) into the tab - so that the information displayed relates to the selected environment / deployed version of the service in that environment.

Note that the platform dependencies displayed on the "latest" tab are sourced from master (as at present) i.e. they are not sourced from a slug, whereas the dependencies displayed on all other tabs are pulled from the slug relating to the version of the service deployed in that environment. 