### PR TITLE
BDOG-525: Populate Platform Dependencies on Latest service page tab from slug

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnector.scala
@@ -94,11 +94,13 @@ class ServiceDependenciesConnector @Inject()(
       }
   }
 
-  def getCuratedSlugDependencies(serviceName: String, version: String)(implicit hc: HeaderCarrier): Future[Seq[Dependency]] = {
+  def getCuratedSlugDependencies(serviceName: String, version: Option[String] = None)
+                                (implicit hc: HeaderCarrier): Future[Seq[Dependency]] = {
     import Dependencies.Implicits.readsDependency
-    val url = s"$servicesDependenciesBaseUrl/slug-dependencies/${encodePathParam(serviceName)}/${encodePathParam(version)}"
+    val url = s"$servicesDependenciesBaseUrl/slug-dependencies/${encodePathParam(serviceName)}"
+    val queryParams = buildQueryParams("version" -> version)
 
-    http.GET[Seq[Dependency]](url).recover {
+    http.GET[Seq[Dependency]](url, queryParams).recover {
       case NonFatal(ex) =>
         Logger.error(s"An error occurred when connecting to [$url]: ${ex.getMessage}", ex)
         Nil


### PR DESCRIPTION
Populate the 'Platform Dependencies' section on the 'Latest' tab of a Service page from slug info dependencies rather than the parsing of master / GitHub.  This brings 'Latest' into line with the datasource of the other tabs (albeit they target a specific slug version rather than slug flag).