### PR TITLE
Bdog 525 test dependencies

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
@@ -28,6 +28,7 @@ import play.api.mvc._
 import uk.gov.hmrc.cataloguefrontend.DisplayableTeamMember._
 import uk.gov.hmrc.cataloguefrontend.actions.{UmpAuthActionBuilder, VerifySignInStatus}
 import uk.gov.hmrc.cataloguefrontend.connector.RepoType.Library
+import uk.gov.hmrc.cataloguefrontend.connector.SlugInfoFlag.Latest
 import uk.gov.hmrc.cataloguefrontend.connector.UserManagementConnector.UMPError
 import uk.gov.hmrc.cataloguefrontend.connector._
 import uk.gov.hmrc.cataloguefrontend.events._
@@ -305,18 +306,11 @@ class CatalogueController @Inject()(
             envName -> deployments.filter(_.environmentMapping.name == envName)
           }.toMap
 
-          /*
-           * Note that we ignore libraryDependencies obtained from parsing master / GitHub, and instead use those
-           * from the 'latest' slug.  As such, 'Platform Dependencies' on all tabs (including 'Latest') is populated
-           * from slug info.
-           * Slugs do not contain build related information however.  So 'Build Tools' continues to display information
-           * parsed from master / GitHub.
-           */
           Ok(
             serviceInfoPage(
               repositoryDetails.copy(environments = optDeployedEnvironments, jenkinsURL = jenkinsLink),
-              optMasterDependencies.map(_.copy(libraryDependencies = librariesOfLatestSlug)),
-              librariesBySlugVersion,
+              optMasterDependencies,
+              librariesBySlugVersion + (Latest.asString -> librariesOfLatestSlug),
               repositoryDetails.createdAt,
               deploymentsByEnvironmentName,
               urlIfLeaksFound,

--- a/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
@@ -28,7 +28,6 @@ import play.api.mvc._
 import uk.gov.hmrc.cataloguefrontend.DisplayableTeamMember._
 import uk.gov.hmrc.cataloguefrontend.actions.{UmpAuthActionBuilder, VerifySignInStatus}
 import uk.gov.hmrc.cataloguefrontend.connector.RepoType.Library
-import uk.gov.hmrc.cataloguefrontend.connector.SlugInfoFlag.Latest
 import uk.gov.hmrc.cataloguefrontend.connector.UserManagementConnector.UMPError
 import uk.gov.hmrc.cataloguefrontend.connector._
 import uk.gov.hmrc.cataloguefrontend.events._
@@ -310,7 +309,8 @@ class CatalogueController @Inject()(
             serviceInfoPage(
               repositoryDetails.copy(environments = optDeployedEnvironments, jenkinsURL = jenkinsLink),
               optMasterDependencies,
-              librariesBySlugVersion + (Latest.asString -> librariesOfLatestSlug),
+              librariesBySlugVersion,
+              librariesOfLatestSlug,
               repositoryDetails.createdAt,
               deploymentsByEnvironmentName,
               urlIfLeaksFound,

--- a/app/uk/gov/hmrc/cataloguefrontend/ServiceInfoView.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/ServiceInfoView.scala
@@ -47,15 +47,12 @@ object ServiceInfoView {
     }
 
   /*
-   * Capture any curated library dependencies from master/Github that are not referenced by the 'latest' slug,
+   * Capture any curated library dependencies from master / Github that are not referenced by the 'latest' slug,
    * and assume that they represent 'test-only' library dependencies.
    */
-  def buildToolsFrom(optMasterDependencies: Option[Dependencies], librariesOfLatestSlug: Option[Seq[Dependency]]): Option[Dependencies] =
+  def buildToolsFrom(optMasterDependencies: Option[Dependencies], librariesOfLatestSlug: Seq[Dependency]): Option[Dependencies] =
     optMasterDependencies.map { masterDependencies =>
-      val libraryNamesInLatestSlug = librariesOfLatestSlug.map { libraries =>
-        libraries.map(_.name)
-      }.getOrElse(Seq.empty).toSet
-
+      val libraryNamesInLatestSlug = librariesOfLatestSlug.map(_.name).toSet
       masterDependencies.copy(
         libraryDependencies = masterDependencies.libraryDependencies.filterNot { library =>
           libraryNamesInLatestSlug.contains(library.name)
@@ -68,10 +65,10 @@ object ServiceInfoView {
    * from the 'latest' slug.  This provides consistency in that 'Platform Dependencies' is always populated from a slug,
    * regardless of the selected tab.
    */
-  def platformDependenciesFrom(optMasterDependencies: Option[Dependencies], librariesOfLatestSlug: Option[Seq[Dependency]]): Option[Dependencies] =
+  def platformDependenciesFrom(optMasterDependencies: Option[Dependencies], librariesOfLatestSlug: Seq[Dependency]): Option[Dependencies] =
     optMasterDependencies.map {
       _.copy(
-        libraryDependencies = librariesOfLatestSlug.getOrElse(Seq.empty)
+        libraryDependencies = librariesOfLatestSlug
       )
     }
 }

--- a/app/views/ServiceInfoPage.scala.html
+++ b/app/views/ServiceInfoPage.scala.html
@@ -30,6 +30,7 @@
 @(service: RepositoryDetails,
   optMasterDependencies: Option[Dependencies],
   dependenciesByVersion: Map[String, Seq[Dependency]],
+  librariesOfLatestSlug: Seq[Dependency],
   repositoryCreationDate: LocalDateTime,
   deploymentsByEnvironmentName: Map[String, Seq[DeploymentVO]],
   linkToLeakDetection: Option[String],
@@ -88,7 +89,7 @@
 
         @dependenciesByEnvironmentPartial(
             service,
-            ServiceInfoView.platformDependenciesFrom(optMasterDependencies, dependenciesByVersion.get(Latest.asString)),
+            ServiceInfoView.platformDependenciesFrom(optMasterDependencies, librariesOfLatestSlug),
             dependenciesByVersion,
             deploymentsByEnvironmentName,
             shutterState
@@ -96,7 +97,7 @@
 
         <div class="row">
             <div class="col-md-12">
-                @buildToolsPartial(ServiceInfoView.buildToolsFrom(optMasterDependencies, dependenciesByVersion.get(Latest.asString)))
+                @buildToolsPartial(ServiceInfoView.buildToolsFrom(optMasterDependencies, librariesOfLatestSlug))
             </div>
         </div>
     </section>

--- a/app/views/ServiceInfoPage.scala.html
+++ b/app/views/ServiceInfoPage.scala.html
@@ -19,6 +19,7 @@
 @import play.twirl.api.Html
 @import uk.gov.hmrc.cataloguefrontend.connector.RepositoryDetails
 @import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependencies, Dependency}
+@import uk.gov.hmrc.cataloguefrontend.connector.SlugInfoFlag.Latest
 @import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.{EnvironmentRoute, ServiceRoutes}
 @import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment => ShutteringEnvironment, ShutterState}
 @import uk.gov.hmrc.cataloguefrontend.{DeploymentVO, ServiceInfoView, ViewMessages}
@@ -27,7 +28,7 @@
 @this(dependenciesByEnvironmentPartial: DependenciesByEnvironmentPartial, buildToolsPartial: BuildToolsPartial, viewMessages: ViewMessages)
 
 @(service: RepositoryDetails,
-  optLatestDependencies: Option[Dependencies],
+  optMasterDependencies: Option[Dependencies],
   dependenciesByVersion: Map[String, Seq[Dependency]],
   repositoryCreationDate: LocalDateTime,
   deploymentsByEnvironmentName: Map[String, Seq[DeploymentVO]],
@@ -48,8 +49,8 @@
     </header>
 
     @partials.leak_detection_banner(linkToLeakDetection)
-    @partials.bobby_active_violations_banner(optLatestDependencies.map(_.toSeq).getOrElse(Seq.empty))
-    @partials.bobby_pending_violations_banner(optLatestDependencies.map(_.toSeq).getOrElse(Seq.empty))
+    @partials.bobby_active_violations_banner(optMasterDependencies.map(_.toSeq).getOrElse(Seq.empty))
+    @partials.bobby_pending_violations_banner(optMasterDependencies.map(_.toSeq).getOrElse(Seq.empty))
 
     <section class="section-wrapper">
 
@@ -86,12 +87,16 @@
         </div>
 
         @dependenciesByEnvironmentPartial(
-            service, optLatestDependencies, dependenciesByVersion, deploymentsByEnvironmentName, shutterState
+            service,
+            ServiceInfoView.platformDependenciesFrom(optMasterDependencies, dependenciesByVersion.get(Latest.asString)),
+            dependenciesByVersion,
+            deploymentsByEnvironmentName,
+            shutterState
         )
 
         <div class="row">
             <div class="col-md-12">
-                @buildToolsPartial(optLatestDependencies)
+                @buildToolsPartial(ServiceInfoView.buildToolsFrom(optMasterDependencies, dependenciesByVersion.get(Latest.asString)))
             </div>
         </div>
     </section>

--- a/app/views/partials/BuildToolsPartial.scala.html
+++ b/app/views/partials/BuildToolsPartial.scala.html
@@ -19,28 +19,47 @@
 
 @this(viewMessages: ViewMessages)
 
-@(mayBeDependencies: Option[Dependencies])
+@(mayBeDependencies: Option[Dependencies])(implicit messages: Messages)
 
 
 <div id="build_tools" class="board">
-    <h3 class="board__heading">Build Tools</h3>
+    <h3 class="board__heading">
+        Latest Build
+        <img class="info-icon" src="/assets/infoicon.svg" data-toggle="tooltip" data-placement="right" title="@messages("latestbuild.info")"/>
+    </h3>
     <div class="board__body">
         <div class="col-xs-8">
             <ul class="list list--minimal list-group row">
                 @if(dependencyDataAvailable()) {
-                <li>
-                    <span class="col-xs-4"><label>Sbt plugins</label></span>
-                    <span class="col-xs-3"><label>Current Version</label></span>
-                    <span class="col-xs-3"><label>Latest Version</label></span>
-                    <span class="col-xs-2"><label>Violation</label></span>
-                </li>
-                @partials.dependency_section(mayBeDependencies.get.sbtPluginsDependencies)
 
-                <li><span class="col-xs-12">&nbsp;</span></li>
-                <li><span class="col-xs-12"><label>Other</label></span></li>
-                @partials.dependency_section(mayBeDependencies.get.otherDependencies)
+                    @if(mayBeDependencies.map(_.libraryDependencies.nonEmpty).getOrElse(false)) {
+                    <li>
+                        <span class="col-xs-4"><label>Test libraries</label></span>
+                        <span class="col-xs-3"><label>Current Version</label></span>
+                        <span class="col-xs-3"><label>Latest Version</label></span>
+                        <span class="col-xs-2"><label>Violation</label></span>
+                    </li>
+                    @partials.dependency_section(mayBeDependencies.get.libraryDependencies)
+                    }
+
+                    @if(mayBeDependencies.map(_.libraryDependencies.isEmpty).getOrElse(true)) {
+                    <li>
+                        <span class="col-xs-4"><label>Sbt plugins</label></span>
+                        <span class="col-xs-3"><label>Current Version</label></span>
+                        <span class="col-xs-3"><label>Latest Version</label></span>
+                        <span class="col-xs-2"><label>Violation</label></span>
+                    </li>
+                    } else {
+                    <li><span class="col-xs-12">&nbsp;</span></li>
+                    <li><span class="col-xs-12"><label>Sbt plugins</label></span></li>
+                    }
+                    @partials.dependency_section(mayBeDependencies.get.sbtPluginsDependencies)
+
+                    <li><span class="col-xs-12">&nbsp;</span></li>
+                    <li><span class="col-xs-12"><label>Other</label></span></li>
+                    @partials.dependency_section(mayBeDependencies.get.otherDependencies)
                 } else {
-                <li>No Build Tools available</li>
+                    <li>No Latest Build available</li>
                 }
             </ul>
         </div>
@@ -50,7 +69,6 @@
     </div>
 
     @dependencyDataAvailable() = @{
-        mayBeDependencies.isDefined &&
-        (mayBeDependencies.get.sbtPluginsDependencies.nonEmpty || mayBeDependencies.get.otherDependencies.nonEmpty)
+        mayBeDependencies.toSeq.nonEmpty
     }
 </div>

--- a/app/views/partials/DependenciesByEnvironmentPartial.scala.html
+++ b/app/views/partials/DependenciesByEnvironmentPartial.scala.html
@@ -28,8 +28,7 @@
   dependenciesByVersion: Map[String, Seq[Dependency]],
   deploymentsByEnvironmentName: Map[String, Seq[DeploymentVO]],
   shutterState: Map[ShutteringEnvironment, ShutterState]
-)
-
+)(implicit messages: Messages)
 
 <ul id="environmentTabs" class="nav nav-tabs" role="tablist">
     <!-- we hard-code 'latest' as it is not a deployment 'environment' -->

--- a/app/views/partials/ServiceDependenciesPartial.scala.html
+++ b/app/views/partials/ServiceDependenciesPartial.scala.html
@@ -19,11 +19,14 @@
 
 @this(viewMessages: ViewMessages)
 
-@(dependencies: Seq[Dependency], rootId: String)
+@(dependencies: Seq[Dependency], rootId: String)(implicit messages: Messages)
 
 
 <div id="@rootId" class="board">
-    <h3 class="board__heading">Platform Dependencies</h3>
+    <h3 class="board__heading">
+        Platform Dependencies
+        <img class="info-icon" src="/assets/infoicon.svg" data-toggle="tooltip" data-placement="right" title="@messages("platformdependencies.info")"/>
+    </h3>
     <div class="board__body">
     <div class="col-xs-8">
             <ul class="list list--minimal list-group row">

--- a/app/views/partials/dependency_section.scala.html
+++ b/app/views/partials/dependency_section.scala.html
@@ -19,7 +19,7 @@
 @(dependencies: Seq[Dependency])
 
 
-@for(dependency <- dependencies)  {
+@for(dependency <- dependencies.sortBy(_.name))  {
         <li>
             <div class="@{getColourClass(dependency)}" id="@{dependency.name}">
                 <span class="col-xs-4 left-aligned">

--- a/conf/messages
+++ b/conf/messages
@@ -11,3 +11,6 @@ sign-in.wrong-credentials=Invalid username or password
 dependencyexplorer.select.group=Select Group
 dependencyexplorer.select.artefact=Select Artefact
 dependencyexplorer.select.teams.all=All teams
+
+platformdependencies.info=A curated selection of runtime dependencies built into the versioned distributable
+latestbuild.info=A curated selection of development dependencies determined by parsing build files on the master branch


### PR DESCRIPTION
Assume that library dependencies derived from parsing build files on master that are not known to the appropriate "latest" tagged "slug-info" represent "test-only" library dependencies.  Examples are typically _reactivemongo-test_ and _hmrctest_.  Add such dependencies to what was previously called the "Build Tools" section under the heading "Test libraries", and rename the section to "Latest Build" (as it is no longer just about "tools").

Sort the display of dependencies by name - they are currently displayed in the order retrieved from the database.
 