### PR TITLE
BDOG-528: remove Jenkins from displayed telemetry links

### DIFF
--- a/app/views/partials/DependenciesByEnvironmentPartial.scala.html
+++ b/app/views/partials/DependenciesByEnvironmentPartial.scala.html
@@ -98,7 +98,7 @@
                             </li>
                             } else {
                             @for(tool <- environment.services) {
-                            <li class="list-item col-xs-4">
+                            <li class="list-item col-xs-6">
                                 <a id="link-to-@{tool.id}-@{environment.id}" href="@{tool.url}" target="_blank">
                                     @{tool.displayName}<span class="glyphicon glyphicon-new-window"></span>
                                 </a>

--- a/test/uk/gov/hmrc/cataloguefrontend/CatalogueControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/CatalogueControllerSpec.scala
@@ -25,6 +25,7 @@ import org.mockito.Mockito.when
 import org.scalatest.Matchers._
 import org.scalatest.{BeforeAndAfter, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
@@ -162,6 +163,7 @@ class CatalogueControllerSpec extends WordSpec with MockitoSugar with BeforeAndA
       mock[VerifySignInStatus],
       mock[UmpAuthActionBuilder],
       userManagementPortalConfig,
+      Configuration.empty,
       stubMessagesControllerComponents(),
       mock[DigitalServiceInfoPage],
       mock[IndexPage],

--- a/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
@@ -23,11 +23,11 @@ import org.mockito.Matchers._
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET => _, _}
+import play.api.{Application, Configuration}
 import uk.gov.hmrc.cataloguefrontend.actions.{ActionsSupport, UmpVerifiedRequest}
 import uk.gov.hmrc.cataloguefrontend.connector.UserManagementAuthConnector.User
 import uk.gov.hmrc.cataloguefrontend.connector.UserManagementConnector.{TeamMember, UMPError}
@@ -360,6 +360,7 @@ class DigitalServicePageSpec
       verifySignInStatusPassThrough,
       umpAuthenticatedPassThrough,
       userManagementPortalConfig,
+      Configuration.empty,
       stubMessagesControllerComponents(),
       digitalServiceInfoPage,
       mock[IndexPage],

--- a/test/uk/gov/hmrc/cataloguefrontend/LibrariesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/LibrariesSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cataloguefrontend
 
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.actions.{UmpAuthActionBuilder, VerifySignInStatus}
@@ -57,6 +58,7 @@ class LibrariesSpec extends UnitSpec with MockitoSugar {
     mock[VerifySignInStatus],
     mock[UmpAuthActionBuilder],
     mock[UserManagementPortalConfig],
+    Configuration.empty,
     stubMessagesControllerComponents(),
     mock[DigitalServiceInfoPage],
     mock[IndexPage],

--- a/test/uk/gov/hmrc/cataloguefrontend/PrototypesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/PrototypesSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cataloguefrontend
 
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.actions.{UmpAuthActionBuilder, VerifySignInStatus}
@@ -57,6 +58,7 @@ class PrototypesSpec extends UnitSpec with MockitoSugar {
     mock[VerifySignInStatus],
     mock[UmpAuthActionBuilder],
     mock[UserManagementPortalConfig],
+    Configuration.empty,
     stubMessagesControllerComponents(),
     mock[DigitalServiceInfoPage],
     mock[IndexPage],

--- a/test/uk/gov/hmrc/cataloguefrontend/ServiceOwnerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/ServiceOwnerSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.cataloguefrontend
 import org.mockito.Matchers._
 import org.mockito.Mockito.{verify, verifyZeroInteractions, when}
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.test.FakeRequest
@@ -174,6 +175,7 @@ class ServiceOwnerSpec extends UnitSpec with MockitoSugar with ActionsSupport {
       new VerifySignInStatusPassThrough(umac, controllerComponents),
       new UmpAuthenticatedPassThrough(umac, controllerComponents, catalogueErrorHandler),
       userManagementPortalConfig,
+      Configuration.empty,
       controllerComponents,
       mock[DigitalServiceInfoPage],
       mock[IndexPage],

--- a/test/uk/gov/hmrc/cataloguefrontend/ServicesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/ServicesSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.cataloguefrontend
 
 import org.scalatestplus.mockito.MockitoSugar
+import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.actions.{UmpAuthActionBuilder, VerifySignInStatus}
@@ -57,6 +58,7 @@ class ServicesSpec extends UnitSpec with MockitoSugar {
     mock[VerifySignInStatus],
     mock[UmpAuthActionBuilder],
     mock[UserManagementPortalConfig],
+    Configuration.empty,
     stubMessagesControllerComponents(),
     mock[DigitalServiceInfoPage],
     mock[IndexPage],


### PR DESCRIPTION
The Jenkins link in the "services" array exposed by teams-and-repositories "respositoryDetails" is a link to deploy-microservice which is not service specific.  This should not be displayed on the Service Page in the "Telemetry" section - which should contain only links to Grafana & Kibana (which are tailored for the relevant service & environment).

Note that these links are driven by teams-and-repositories config, and so we must allow the target link name to also be configured in catalogue-frontend.  If no such config is defined we fall back to a sensible default (the current value).