### PR TITLE
BDOG-545 disable JUnitXmlReportPlugin to prevent junit test-case outp…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val silencerVersion = "1.4.4"
 lazy val microservice = Project(appName, file("."))
   .enablePlugins(
     Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory): _*)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(publishingSettings: _*)
   .settings(
     majorVersion := 4,


### PR DESCRIPTION
…ut file mangling

Upgrading to sbt 1.x looks like it hit this issue: https://github.com/scalatest/scalatest/issues/1427. 

Generated test-reports get sporadically intermangled:
```
xmllint --noout *.xml
TEST-uk.gov.hmrc.cataloguefrontend.CatalogueControllerSpec.xml:18: parser error : Extra content at the end of the document
                   </testsuite>012">
                               ^
TEST-uk.gov.hmrc.cataloguefrontend.connector.ShutterGroupsConnectorSpec.xml:16: parser error : Extra content at the end of the document
                   </testsuite>nd" classname="uk.gov.hmrc.cataloguefrontend.conn
```

This PR disables the experimental JUnitXmlReportPlugin which is conflicting with scalatests own reporter.