### PR TITLE
BDOG-481: add link & summary event description to Shutter Overview

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/DateHelper.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/DateHelper.scala
@@ -27,7 +27,7 @@ object DateHelper {
   val `dd-MM-yyyy`: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
   val `yyyy-MM-dd`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
   val `yyyy-MM-dd HH:mm z`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z")
-  val `yyyy-MM-dd HH:mm:SS z`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS z")
+  val `yyyy-MM-dd HH:mm:ss z`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z")
 
   implicit class JavaDateToLocalDateTime(d: Date) {
     def toLocalDate = LocalDateTime.ofInstant(d.toInstant, ZoneId.systemDefault())

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -136,7 +136,7 @@
         @state.lastEvent.map(_.username).getOrElse("")
       </td>
       <td class="shutter-date">
-        @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:SS z`)).getOrElse("")
+        @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
       </td>
       @if(isSignedIn) {
         <td class="shutter-update">

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import uk.gov.hmrc.cataloguefrontend.DateHelper._
-@import uk.gov.hmrc.cataloguefrontend.shuttering.{routes, Environment, EventData, ShutterStatusValue, ShutterStateData, ShutterType}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.{routes, Environment, EventData, ShutterCause, ShutterStatusValue, ShutterStateChangeEvent, ShutterStateData, ShutterType}
 @import uk.gov.hmrc.cataloguefrontend.ViewMessages
 
 @this(viewMessages: ViewMessages)
@@ -25,7 +25,7 @@
  , selectedEnv   : Environment
  , isSignedIn    : Boolean
  , killSwitchLink: Option[String]
- )(implicit request: Request[_])
+ )(implicit request: Request[_], messages: Messages)
 
 @standard_layout(s"Shutter Overview - ${shutterType.asString.capitalize}") {
 
@@ -129,21 +129,34 @@
         <a class="shutter-row-link" href="@uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(state.serviceName)">
           @state.serviceName
         </a>
+        @if(state.drillDownEvent.isDefined) {
+          <div id="drill-down-@{state.serviceName}-@{state.environment.asString}" class="drill-down-event">
+            @descriptionOf(state.drillDownEvent)
+          </div>
+        }
       </td>
       <td class="shutter-state">
         @state.status.value
       </td>
       <td class="shutter-user">
-        @state.lastEvent.map(_.username).getOrElse("")
+        @usernameFor(state.lastEvent)
       </td>
       <td class="shutter-date">
         @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
       </td>
       <td>
         @if(state.lastEvent.isDefined) {
-          <a class="medium-glyphicon glyphicon glyphicon-list" href="@routes.ShutterEventsController.shutterEventsList(state.environment, Some(state.serviceName))"></a>
+          <a id="event-history-link-@{state.serviceName}-@{state.environment.asString}"
+             class="medium-glyphicon glyphicon glyphicon-list"
+             data-toggle="tooltip"
+             data-placement="right"
+             title="@messages("shutter-event.history")"
+             href="@routes.ShutterEventsController.shutterEventsList(state.environment, Some(state.serviceName))"></a>
+        } else {
+          @Html("No events")
         }
       </td>
+
       @if(isSignedIn) {
         <td class="shutter-update">
           <a id="shutter-link" class="shutter-row-link" href="@routes.ShutterWizardController.start(state.shutterType, state.environment, Some(state.serviceName))">
@@ -152,4 +165,16 @@
         </td>
       }
   </tr>
+}
+
+@usernameFor(eventOpt: Option[ShutterStateChangeEvent]) = @{
+  eventOpt.map { evt =>
+    if (evt.cause == ShutterCause.AutoReconciled) "auto-reconciler" else evt.username
+  }.getOrElse("")
+}
+
+@descriptionOf(eventOpt: Option[ShutterStateChangeEvent]) = @{
+  eventOpt.map { evt =>
+    s"(previously ${evt.status.value.asString} by ${evt.username} at ${evt.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)})"
+  }.getOrElse("")
 }

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import uk.gov.hmrc.cataloguefrontend.DateHelper._
-@import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, EventData, ShutterStatusValue, ShutterStateData, ShutterType}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.{routes, Environment, EventData, ShutterStatusValue, ShutterStateData, ShutterType}
 @import uk.gov.hmrc.cataloguefrontend.ViewMessages
 
 @this(viewMessages: ViewMessages)
@@ -63,6 +63,7 @@
                   <th id="status-header"><p class="shutter-overview-header">Status</p></th>
                   <th id="last-update-by-header"><p class="shutter-overview-header">Last updated by</p></th>
                   <th id="date-header"><p class="shutter-overview-header">Date</p></th>
+                  <th id="events-link"><p class="shutter-overview-header">Events</p></th>
                   @if(isSignedIn) { <th id="update-header"><p class="shutter-overview-header">Update</p></th> }
               </tr>
           </thead>
@@ -125,7 +126,7 @@
 @shutterRow(state: ShutterStateData) = {
   <tr class="shutter-row @classFor(state.status.value)">
       <td class="shutter-service">
-        <a href="@uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(state.serviceName)">
+        <a class="shutter-row-link" href="@uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(state.serviceName)">
           @state.serviceName
         </a>
       </td>
@@ -138,9 +139,14 @@
       <td class="shutter-date">
         @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
       </td>
+      <td>
+        @if(state.lastEvent.isDefined) {
+          <a class="medium-glyphicon glyphicon glyphicon-list" href="@routes.ShutterEventsController.shutterEventsList(state.environment, Some(state.serviceName))"></a>
+        }
+      </td>
       @if(isSignedIn) {
         <td class="shutter-update">
-          <a id="shutter-link" href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterWizardController.start(state.shutterType, state.environment, Some(state.serviceName))">
+          <a id="shutter-link" class="shutter-row-link" href="@routes.ShutterWizardController.start(state.shutterType, state.environment, Some(state.serviceName))">
             @changeValueFor(state.status.value)
           </a>
         </td>

--- a/conf/messages
+++ b/conf/messages
@@ -21,3 +21,5 @@ bobbyrules.pending.badge=Bobby rule pending
 
 whatsrunningwhere.select.profile=Any Profile
 whatsrunningwhere.select.team=Any Team
+
+shutter-event.history=Event History

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -12342,3 +12342,20 @@ table.shutter-events {
   background-color: #ffbf00;
   border: 1px solid #ffbf00;
 }
+
+#shutter-state-table td {
+  padding-bottom: 24px;
+}
+
+.drill-down-event {
+  position: absolute;
+  top: 60%;
+  left: 102%;
+  white-space: nowrap;
+  font-style: italic;
+  font-size: 0.9rem;
+}
+
+.shutter-service {
+  position: relative;
+}

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -12163,7 +12163,7 @@ tr.shuttered_row td p {
     margin: 0px;
 }
 
-tr.shuttered_row td a {
+tr.shuttered_row td .shutter-row-link {
     background: #333333;
     color: #fff;
     border-radius: 3px;


### PR DESCRIPTION
Add to Shutter Overview:
* a link to the appropriate shutter event history
* a summary description of the last event that was not created by the auto-reconciler, when the last event is an auto-reconciliation event

Also fixes a minor issue with timestamps displaying an incorrect value for seconds.