### PR TITLE
BDOG-481: add links to Shutter Event History from Shutter Overview

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/DateHelper.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/DateHelper.scala
@@ -27,7 +27,7 @@ object DateHelper {
   val `dd-MM-yyyy`: DateTimeFormatter = DateTimeFormatter.ofPattern("dd-MM-yyyy")
   val `yyyy-MM-dd`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
   val `yyyy-MM-dd HH:mm z`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm z")
-  val `yyyy-MM-dd HH:mm:SS z`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:SS z")
+  val `yyyy-MM-dd HH:mm:ss z`: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z")
 
   implicit class JavaDateToLocalDateTime(d: Date) {
     def toLocalDate = LocalDateTime.ofInstant(d.toInstant, ZoneId.systemDefault())

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -136,7 +136,7 @@
         @state.lastEvent.map(_.username).getOrElse("")
       </td>
       <td class="shutter-date">
-        @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:SS z`)).getOrElse("")
+        @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
       </td>
       @if(isSignedIn) {
         <td class="shutter-update">

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import uk.gov.hmrc.cataloguefrontend.DateHelper._
-@import uk.gov.hmrc.cataloguefrontend.shuttering.{Environment, EventData, ShutterStatusValue, ShutterStateData, ShutterType}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.{routes, Environment, EventData, ShutterCause, ShutterStateChangeEvent, ShutterStateData, ShutterStatusValue, ShutterType}
 @import uk.gov.hmrc.cataloguefrontend.ViewMessages
 
 @this(viewMessages: ViewMessages)
@@ -25,7 +25,7 @@
  , selectedEnv   : Environment
  , isSignedIn    : Boolean
  , killSwitchLink: Option[String]
- )(implicit request: Request[_])
+ )(implicit request: Request[_], messages: Messages)
 
 @standard_layout(s"Shutter Overview - ${shutterType.asString.capitalize}") {
 
@@ -63,6 +63,7 @@
                   <th id="status-header"><p class="shutter-overview-header">Status</p></th>
                   <th id="last-update-by-header"><p class="shutter-overview-header">Last updated by</p></th>
                   <th id="date-header"><p class="shutter-overview-header">Date</p></th>
+                  <th id="events-link"><p class="shutter-overview-header">Events</p></th>
                   @if(isSignedIn) { <th id="update-header"><p class="shutter-overview-header">Update</p></th> }
               </tr>
           </thead>
@@ -125,7 +126,7 @@
 @shutterRow(state: ShutterStateData) = {
   <tr class="shutter-row @classFor(state.status.value)">
       <td class="shutter-service">
-        <a href="@uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(state.serviceName)">
+        <a class="shutter-row-link" href="@uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(state.serviceName)">
           @state.serviceName
         </a>
       </td>
@@ -133,17 +134,35 @@
         @state.status.value
       </td>
       <td class="shutter-user">
-        @state.lastEvent.map(_.username).getOrElse("")
+        @usernameFor(state.lastEvent)
       </td>
       <td class="shutter-date">
         @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
       </td>
+      <td>
+        @if(state.lastEvent.isDefined) {
+          <a id="event-history-link-@{state.serviceName}-@{state.environment.asString}"
+             class="medium-glyphicon glyphicon glyphicon-list"
+             data-toggle="tooltip"
+             data-placement="right"
+             title="@messages("shutter-event.history")"
+             href="@routes.ShutterEventsController.shutterEventsList(state.environment, Some(state.serviceName))"></a>
+        } else {
+          @Html("No events")
+        }
+      </td>
       @if(isSignedIn) {
         <td class="shutter-update">
-          <a id="shutter-link" href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterWizardController.start(state.shutterType, state.environment, Some(state.serviceName))">
+          <a id="shutter-link" class="shutter-row-link" href="@routes.ShutterWizardController.start(state.shutterType, state.environment, Some(state.serviceName))">
             @changeValueFor(state.status.value)
           </a>
         </td>
       }
   </tr>
+}
+
+@usernameFor(eventOpt: Option[ShutterStateChangeEvent]) = @{
+  eventOpt.map { evt =>
+    if (evt.cause == ShutterCause.AutoReconciled) "<outside the catalogue>" else evt.username
+  }.getOrElse("")
 }

--- a/conf/messages
+++ b/conf/messages
@@ -21,3 +21,5 @@ bobbyrules.pending.badge=Bobby rule pending
 
 whatsrunningwhere.select.profile=Any Profile
 whatsrunningwhere.select.team=Any Team
+
+shutter-event.history=Event History

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -12163,7 +12163,7 @@ tr.shuttered_row td p {
     margin: 0px;
 }
 
-tr.shuttered_row td a {
+tr.shuttered_row td .shutter-row-link {
     background: #333333;
     color: #fff;
     border-radius: 3px;


### PR DESCRIPTION
* add appropriate link to shutter event history if there is at least one shutter event, else display 'No events'
* change the displayed username on auto-reconciliation events from 'shutter-api' to '<outside the catalogue>'

* also fixes issue where timestamps had incorrect values for the seconds component