### PR TITLE
Bdog 609

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
@@ -24,7 +24,6 @@ import play.api.Configuration
 import play.api.data.Forms._
 import play.api.data.{Form, Mapping}
 import play.api.libs.json.Json.toJson
-import play.api.libs.json.{Format, Json}
 import play.api.mvc._
 import uk.gov.hmrc.cataloguefrontend.DisplayableTeamMember._
 import uk.gov.hmrc.cataloguefrontend.actions.{UmpAuthActionBuilder, VerifySignInStatus}
@@ -37,7 +36,6 @@ import uk.gov.hmrc.cataloguefrontend.model.{Environment, SlugInfoFlag}
 import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, DeploymentsService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.{ShutterService, ShutterState, ShutterType}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import uk.gov.hmrc.play.bootstrap.http.ErrorResponse
 import views.html._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -97,8 +95,6 @@ class CatalogueController @Inject()(
 
   // this value must match the configured name property for jenkins services defined under url-templates.environments at https://github.com/hmrc/app-config-base/blob/master/teams-and-repositories.conf
   private lazy val jenkinsLinkName = configuration.getOptional[String]("teams-and-repositories.link-name.jenkins").getOrElse("jenkins")
-
-  private implicit val errorResponseFormat: Format[ErrorResponse] = Json.format[ErrorResponse]
 
   private val repoTypeToDetailsUrl = Map(
     RepoType.Service   -> routes.CatalogueController.service _,

--- a/app/uk/gov/hmrc/cataloguefrontend/DependencyReportController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/DependencyReportController.scala
@@ -107,8 +107,8 @@ class DependencyReportController @Inject()(
       case Some(VersionState.MinorVersionOutOfDate) => "amber"
       case Some(VersionState.MajorVersionOutOfDate) => "red"
       case Some(VersionState.Invalid)               => "N/A"
-      case Some(VersionState.BobbyRuleViolated)     => "verybad"
-      case Some(VersionState.BobbyRulePending)      => "pending"
+      case Some(_: VersionState.BobbyRuleViolated)  => "verybad"
+      case Some(_: VersionState.BobbyRulePending)   => "pending"
       case None                                     => "grey"
     }
 

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRule.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRule.scala
@@ -28,7 +28,10 @@ case class BobbyRule(
   , range   : BobbyVersionRange
   , reason  : String
   , from    : LocalDate
-  )
+  ) {
+    def id: String =
+      s"$group:$artefact:$range"
+  }
 
 object BobbyRule {
   val reads: Reads[BobbyRule] = {

--- a/app/views/BobbyExplorerPage.scala.html
+++ b/app/views/BobbyExplorerPage.scala.html
@@ -83,7 +83,7 @@
 
 
 @bobbyRuleRow(inclViewSlugsLink: Boolean)(rule: BobbyRule) = {
-    <tr id="rule-@rule.artefact" class="bobby-rule">
+    <tr id="rule-@rule.id" class="bobby-rule">
         <td>@rule.group:@rule.artefact</td>
         @defining(rule.range.rangeDescr) { rangeDescr =>
             @rangeDescr match {

--- a/app/views/partials/dependency_section.scala.html
+++ b/app/views/partials/dependency_section.scala.html
@@ -20,28 +20,30 @@
 
 
 @for(dependency <- dependencies.sortBy(_.name))  {
-        <li>
-            <div class="@{getColourClass(dependency)}" id="@{dependency.name}">
-                <span class="col-xs-4 left-aligned">
-                    <span id="@{dependency.name}-icon" class="@{getIconClass(dependency)}" title="@{getAltText(dependency)}"> </span>
-                    @if(dependency.latestVersion.isDefined && !dependency.isExternal) {
-                        <a id="link-to-@{dependency.name}" href="/repositories/@{dependency.name}">@dependency.name</a>
-                    } else {
-                        @dependency.name
-                    }
-                </span>
-                <span id="@{dependency.name}-current-version" class="col-xs-3">@dependency.currentVersion.toString</span>
-                <span id="@{dependency.name}-latestVersion-version" class="col-xs-3">
-                    <span class="glyphicon glyphicon-arrow-right small-glyphicon" style="padding-right: 10px;"> </span>
-                    @dependency.latestVersion.map(_.toString).getOrElse("(not found)")
-                </span>
-                <span id="@{dependency.name}-bobbyrule" class="col-xs-2">
-                    @if(dependency.versionState.fold(false)(v => List(VersionState.BobbyRuleViolated, VersionState.BobbyRulePending).contains(v))) {
-                        <a href="@{appRoutes.BobbyExplorerController.list()}#@{dependency.name}">See rule</a>
-                    } else { }
-                </span>
-            </div>
-        </li>
+  <li>
+      <div class="@{getColourClass(dependency)}" id="@{dependency.name}">
+          <span class="col-xs-4 left-aligned">
+              <span id="@{dependency.name}-icon" class="@{getIconClass(dependency)}" title="@{getAltText(dependency)}"> </span>
+              @if(dependency.latestVersion.isDefined && !dependency.isExternal) {
+                  <a id="link-to-@{dependency.name}" href="/repositories/@{dependency.name}">@dependency.name</a>
+              } else {
+                  @dependency.name
+              }
+          </span>
+          <span id="@{dependency.name}-current-version" class="col-xs-3">@dependency.currentVersion.toString</span>
+          <span id="@{dependency.name}-latestVersion-version" class="col-xs-3">
+              <span class="glyphicon glyphicon-arrow-right small-glyphicon" style="padding-right: 10px;"> </span>
+              @dependency.latestVersion.map(_.toString).getOrElse("(not found)")
+          </span>
+          <span id="@{dependency.name}-bobbyrule" class="col-xs-2">
+              @dependency.versionState match {
+                  case Some(VersionState.BobbyRuleViolated(violation)) => { <a href="@{appRoutes.BobbyExplorerController.list()}#@{dependency.group}:@{dependency.name}:@{violation.range}">See rule</a> }
+                  case Some(VersionState.BobbyRulePending (violation)) => { <a href="@{appRoutes.BobbyExplorerController.list()}#@{dependency.group}:@{dependency.name}:@{violation.range}">See rule</a> }
+                  case _                                               => { }
+              }
+          </span>
+      </div>
+  </li>
 }
 
 @getColourClass(dependency: Dependency) = @{
@@ -50,8 +52,8 @@
         case VersionState.MinorVersionOutOfDate => "amber"
         case VersionState.MajorVersionOutOfDate => "red"
         case VersionState.Invalid               => "black"
-        case VersionState.BobbyRuleViolated     => "verybad"
-        case VersionState.BobbyRulePending      => "pending"
+        case _: VersionState.BobbyRuleViolated  => "verybad"
+        case _: VersionState.BobbyRulePending   => "pending"
     }
 }
 
@@ -61,8 +63,8 @@
         case VersionState.MinorVersionOutOfDate => "glyphicon-alert"
         case VersionState.MajorVersionOutOfDate => "glyphicon-ban-circle"
         case VersionState.Invalid               => "glyphicon-question-sign"
-        case VersionState.BobbyRuleViolated     => "glyphicon-remove"
-        case VersionState.BobbyRulePending      => "glyphicon-remove"
+        case _: VersionState.BobbyRuleViolated  => "glyphicon-remove"
+        case _: VersionState.BobbyRulePending   => "glyphicon-remove"
     }
 }
 
@@ -72,7 +74,7 @@
         case VersionState.MinorVersionOutOfDate => "minor version behind"
         case VersionState.MajorVersionOutOfDate => "major version behind"
         case VersionState.Invalid               => "invalid version difference"
-        case VersionState.BobbyRuleViolated     => "bobby rule violated"
-        case VersionState.BobbyRulePending      => "bobby rule pending"
+        case _: VersionState.BobbyRuleViolated  => "bobby rule violated"
+        case _: VersionState.BobbyRulePending   => "bobby rule pending"
     }
 }

--- a/app/views/shuttering/ShutterEventsPage.scala.html
+++ b/app/views/shuttering/ShutterEventsPage.scala.html
@@ -82,7 +82,7 @@
 
 @makeTab(env: Environment) = {
 <li id="tab-@env.asString" class="navbar-item @if(form("environment").value.contains(env.asString)) {active}">
- <a href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterEventsController.shutterEventsList(env, form("serviceName").value)" class="navbar-link">@env.toString</a>
+  <a href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterEventsController.shutterEventsList(env, form("serviceName").value)" class="navbar-link">@env.displayString</a>
 </li>
 }
 

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -98,7 +98,7 @@
 
 @envOption(env: Environment) = {
   <li id="tab-@env.asString" class="navbar-item @if(env == selectedEnv){active}">
-      <a href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterOverviewController.allStatesForEnv(shutterType, env)" class="navbar-link">@env.toString (@shutteredCount(env) / @serviceCount(env))</a>
+      <a href="@uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterOverviewController.allStatesForEnv(shutterType, env)" class="navbar-link">@env.displayString (@shutteredCount(env) / @serviceCount(env))</a>
   </li>
 }
 

--- a/test/uk/gov/hmrc/cataloguefrontend/DependencyReportControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DependencyReportControllerSpec.scala
@@ -153,12 +153,12 @@ class DependencyReportControllerSpec extends UnitSpec with MockitoSugar with Gui
 
   private def sbtPluginsDependencyState(sbtPluginName: String, majorVersion: Int, colour: String) = {
     val currentVersion = Version(s"$majorVersion.0.0")
-    Dependency(sbtPluginName, currentVersion, latestVersion(currentVersion, colour))
+    Dependency(sbtPluginName, "uk.gov.hmrc", currentVersion, latestVersion(currentVersion, colour))
   }
 
   private def libraryDependency(libraryName: String, majorVersion: Int, colour: String) = {
     val currentVersion = Version(s"$majorVersion.0.0")
-    Dependency(libraryName, currentVersion, latestVersion(currentVersion, colour))
+    Dependency(libraryName, "uk.gov.hmrc", currentVersion, latestVersion(currentVersion, colour))
   }
 
   private def digitalServiceRepository(repoName: String) =

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/ServiceDependenciesConnectorSpec.scala
@@ -78,41 +78,41 @@ class ServiceDependenciesConnectorSpec
           |  "libraryDependencies": [
           |    {
           |      "name": "frontend-bootstrap",
+          |      "group": "uk.gov.hmrc",
           |      "currentVersion": "7.11.0",
           |      "latestVersion": "8.80.0",
-          |      "isExternal": false,
           |      "bobbyRuleViolations": []
           |    },
           |    {
           |      "name": "play-config",
+          |      "group": "uk.gov.hmrc",
           |      "currentVersion": "3.0.0",
           |      "latestVersion": "7.70.0",
-          |      "isExternal": false,
           |      "bobbyRuleViolations": []
           |    }
           |  ],
           |  "sbtPluginsDependencies": [
           |    {
           |      "name": "plugin-1",
+          |      "group": "org",
           |      "currentVersion": "1.0.0",
           |      "latestVersion": "1.1.0",
-          |      "isExternal": true,
           |      "bobbyRuleViolations": []
           |    },
           |    {
           |      "name": "plugin-2",
+          |      "group": "uk.gov.hmrc",
           |      "currentVersion": "2.0.0",
           |      "latestVersion": "2.1.0",
-          |      "isExternal": false,
           |      "bobbyRuleViolations": []
           |    }
           |  ],
           |  "otherDependencies": [
           |    {
           |      "name": "sbt",
+          |      "group": "uk.gov.hmrc",
           |      "currentVersion": "0.13.8",
           |      "latestVersion": "0.13.15",
-          |      "isExternal": false,
           |      "bobbyRuleViolations": []
           |    }
           |  ],
@@ -131,18 +131,18 @@ class ServiceDependenciesConnectorSpec
       response.repositoryName      shouldBe "repo1"
       response.libraryDependencies should contain theSameElementsAs
         Seq(
-          Dependency("frontend-bootstrap", Version("7.11.0"), Some(Version("8.80.0"))),
-          Dependency("play-config", Version("3.0.0"), Some(Version("7.70.0")))
+          Dependency("frontend-bootstrap", "uk.gov.hmrc", Version("7.11.0"), Some(Version("8.80.0"))),
+          Dependency("play-config", "uk.gov.hmrc", Version("3.0.0"), Some(Version("7.70.0")))
         )
 
       response.sbtPluginsDependencies should contain theSameElementsAs
         Seq(
-          Dependency("plugin-1", Version("1.0.0"), Some(Version("1.1.0")), isExternal = true),
-          Dependency("plugin-2", Version("2.0.0"), Some(Version("2.1.0")), isExternal = false)
+          Dependency("plugin-1", "org", Version("1.0.0"), Some(Version("1.1.0"))),
+          Dependency("plugin-2", "uk.gov.hmrc", Version("2.0.0"), Some(Version("2.1.0")))
         )
       response.otherDependencies should contain theSameElementsAs
         Seq(
-          Dependency("sbt", Version("0.13.8"), Some(Version("0.13.15")))
+          Dependency("sbt", "uk.gov.hmrc", Version("0.13.8"), Some(Version("0.13.15")))
         )
 
     }
@@ -189,41 +189,41 @@ class ServiceDependenciesConnectorSpec
           |    "libraryDependencies": [
           |      {
           |        "name": "frontend-bootstrap",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "7.11.0",
           |        "latestVersion": "8.80.0",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      },
           |      {
           |        "name": "play-config",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "3.0.0",
           |        "latestVersion": "7.70.0",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      }
           |    ],
           |    "sbtPluginsDependencies": [
           |      {
           |        "name": "plugin-1",
+          |        "group": "org",
           |        "currentVersion": "1.0.0",
           |        "latestVersion": "1.1.0",
-          |        "isExternal": true,
           |        "bobbyRuleViolations": []
           |      },
           |      {
           |        "name": "plugin-2",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "2.0.0",
           |        "latestVersion": "2.1.0",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      }
           |    ],
           |    "otherDependencies": [
           |      {
           |        "name": "sbt",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "0.13.7",
           |        "latestVersion": "0.13.15",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      }
           |    ],
@@ -234,41 +234,41 @@ class ServiceDependenciesConnectorSpec
           |    "libraryDependencies": [
           |      {
           |        "name": "some-lib-1",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "7.77.0",
           |        "latestVersion": "8.80.0",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      },
           |      {
           |        "name": "some-lib-2",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "3.0.0",
           |        "latestVersion": "7.70.0",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      }
           |    ],
           |    "sbtPluginsDependencies": [
           |      {
           |        "name": "plugin-3",
+          |        "group": "org",
           |        "currentVersion": "1.0.0",
           |        "latestVersion": "1.1.0",
-          |        "isExternal": true,
           |        "bobbyRuleViolations": []
           |      },
           |      {
           |        "name": "plugin-4",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "2.0.0",
           |        "latestVersion": "2.1.0",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      }
           |    ],
           |    "otherDependencies": [
           |      {
           |        "name": "sbt",
+          |        "group": "uk.gov.hmrc",
           |        "currentVersion": "0.13.8",
           |        "latestVersion": "0.13.15",
-          |        "isExternal": false,
           |        "bobbyRuleViolations": []
           |      }
           |    ],
@@ -289,19 +289,19 @@ class ServiceDependenciesConnectorSpec
       response.head.repositoryName      shouldBe "repo1"
       response.head.libraryDependencies should contain theSameElementsAs
         Seq(
-          Dependency("frontend-bootstrap", Version("7.11.0"), Some(Version("8.80.0"))),
-          Dependency("play-config", Version("3.0.0"), Some(Version("7.70.0")))
+          Dependency("frontend-bootstrap", "uk.gov.hmrc", Version("7.11.0"), Some(Version("8.80.0"))),
+          Dependency("play-config", "uk.gov.hmrc", Version("3.0.0"), Some(Version("7.70.0")))
         )
 
       response.head.sbtPluginsDependencies should contain theSameElementsAs
         Seq(
-          Dependency("plugin-1", Version("1.0.0"), Some(Version("1.1.0")), isExternal = true),
-          Dependency("plugin-2", Version("2.0.0"), Some(Version("2.1.0")), isExternal = false)
+          Dependency("plugin-1", "org", Version("1.0.0"), Some(Version("1.1.0"))),
+          Dependency("plugin-2", "uk.gov.hmrc", Version("2.0.0"), Some(Version("2.1.0")))
         )
 
       response.head.otherDependencies should contain theSameElementsAs
         Seq(
-          Dependency("sbt", Version("0.13.7"), Some(Version("0.13.15")))
+          Dependency("sbt", "uk.gov.hmrc", Version("0.13.7"), Some(Version("0.13.15")))
         )
 
       response.last.libraryDependencies.size shouldBe 2
@@ -309,19 +309,19 @@ class ServiceDependenciesConnectorSpec
       response.last.repositoryName      shouldBe "repo2"
       response.last.libraryDependencies should contain theSameElementsAs
         Seq(
-          Dependency("some-lib-1", Version("7.77.0"), Some(Version("8.80.0"))),
-          Dependency("some-lib-2", Version("3.0.0"), Some(Version("7.70.0")))
+          Dependency("some-lib-1", "uk.gov.hmrc", Version("7.77.0"), Some(Version("8.80.0"))),
+          Dependency("some-lib-2", "uk.gov.hmrc", Version("3.0.0"), Some(Version("7.70.0")))
         )
 
       response.last.sbtPluginsDependencies should contain theSameElementsAs
         Seq(
-          Dependency("plugin-3", Version("1.0.0"), Some(Version("1.1.0")), isExternal = true),
-          Dependency("plugin-4", Version("2.0.0"), Some(Version("2.1.0")), isExternal = false)
+          Dependency("plugin-3", "org", Version("1.0.0"), Some(Version("1.1.0"))),
+          Dependency("plugin-4", "uk.gov.hmrc", Version("2.0.0"), Some(Version("2.1.0")))
         )
 
       response.last.otherDependencies should contain theSameElementsAs
         Seq(
-          Dependency("sbt", Version("0.13.8"), Some(Version("0.13.15")))
+          Dependency("sbt", "uk.gov.hmrc", Version("0.13.8"), Some(Version("0.13.15")))
         )
     }
   }
@@ -334,22 +334,22 @@ class ServiceDependenciesConnectorSpec
         willRespondWith = (Status.OK, Some(
           """|[{
              |  "name": "dep1",
+             |  "group": "uk.gov.hmrc",
              |  "currentVersion": {"major": 1, "minor": 0, "patch": 0, "original": "1.0.0"},
-             |  "bobbyRuleViolations": [],
-             |  "isExternal": false
+             |  "bobbyRuleViolations": []
              | },
              | {"name": "dep2",
+             |  "group": "uk.gov.hmrc",
              |  "currentVersion": {"major": 2, "minor": 0, "patch": 0, "original": "2.0.0"},
              |  "latestVersion": {"major": 2, "minor": 1, "patch": 0, "original": "2.1.0"},
-             |  "bobbyRuleViolations": [],
-             |  "isExternal": false
+             |  "bobbyRuleViolations": []
              | }]""".stripMargin)))
 
       val response = serviceDependenciesConnector.getCuratedSlugDependencies(slugName, flag).futureValue
 
       response should contain theSameElementsAs Seq(
-        Dependency(name = "dep1", currentVersion = Version("1.0.0"), latestVersion = None),
-        Dependency(name = "dep2", currentVersion = Version("2.0.0"), latestVersion = Some(Version("2.1.0")))
+        Dependency(name = "dep1", group = "uk.gov.hmrc", currentVersion = Version("1.0.0"), latestVersion = None),
+        Dependency(name = "dep2", group = "uk.gov.hmrc", currentVersion = Version("2.0.0"), latestVersion = Some(Version("2.1.0")))
       )
     }
 

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleViolationSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/model/BobbyRuleViolationSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.connector.model
+
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+import scala.util.Random
+
+import org.scalatest.{FreeSpec, Matchers}
+
+class BobbyRuleViolationSpec extends FreeSpec with Matchers {
+
+  "BobbyRuleViolation" - {
+
+    "should order by next valid version" in {
+      val orderedList =
+        List(
+          BobbyRuleViolation(
+            reason = "reason1"
+          , range  = BobbyVersionRange.parse("[1.0.0,)").get
+          , from   = LocalDate.now
+          )
+        , BobbyRuleViolation(
+            reason = "reason2"
+          , range  = BobbyVersionRange.parse("(,99.99.99)").get
+          , from   = LocalDate.now
+          )
+        , BobbyRuleViolation(
+            reason = "reason3"
+          , range  = BobbyVersionRange.parse("(,2.1.0)").get
+          , from   = LocalDate.now
+          )
+        , BobbyRuleViolation(
+            reason = "reason4"
+          , range  = BobbyVersionRange.parse("(,1.2.0]").get
+          , from   = LocalDate.now
+          )
+        , BobbyRuleViolation(
+            reason = "reason5"
+          , range  = BobbyVersionRange.parse("(,1.2.0)").get
+          , from   = LocalDate.now
+          )
+        , BobbyRuleViolation(
+            reason = "reason6"
+          , range  = BobbyVersionRange.parse("(,1.2.0)").get
+          , from   = LocalDate.now.minus(1, ChronoUnit.DAYS)
+          )
+        )
+      Random.shuffle(orderedList).sorted shouldBe orderedList
+    }
+  }
+}

--- a/test/view/DependenciesSpec.scala
+++ b/test/view/DependenciesSpec.scala
@@ -37,22 +37,22 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
     val dependencies = Dependencies(
       "service",
       Seq(
-        Dependency("lib1-up-to-date", Version("1.0.0"), Some(Version("1.0.0"))),
-        Dependency("lib2-minor-behind", Version("2.0.0"), Some(Version("2.1.0"))),
-        Dependency("lib3-major-behind", Version("3.0.0"), Some(Version("4.0.0"))),
-        Dependency("lib4-patch-behind", Version("3.0.0"), Some(Version("3.0.1"))),
-        Dependency("lib5-no-latest-version", Version("3.0.0"), None),
-        Dependency("lib6-invalid-ahead-current", Version("4.0.0"), Some(Version("3.0.1")))
+        Dependency("lib1-up-to-date", "uk.gov.hmrc", Version("1.0.0"), Some(Version("1.0.0"))),
+        Dependency("lib2-minor-behind", "uk.gov.hmrc", Version("2.0.0"), Some(Version("2.1.0"))),
+        Dependency("lib3-major-behind", "uk.gov.hmrc", Version("3.0.0"), Some(Version("4.0.0"))),
+        Dependency("lib4-patch-behind", "uk.gov.hmrc", Version("3.0.0"), Some(Version("3.0.1"))),
+        Dependency("lib5-no-latest-version", "uk.gov.hmrc", Version("3.0.0"), None),
+        Dependency("lib6-invalid-ahead-current", "uk.gov.hmrc", Version("4.0.0"), Some(Version("3.0.1")))
       ),
       Seq(
-        Dependency("plugin1-up-to-date", Version("1.0.0"), Some(Version("1.0.0"))),
-        Dependency("plugin2-minor-behind", Version("2.0.0"), Some(Version("2.1.0"))),
-        Dependency("plugin3-major-behind", Version("3.0.0"), Some(Version("4.0.0"))),
-        Dependency("plugin4-patch-behind", Version("3.0.0"), Some(Version("3.0.1"))),
-        Dependency("plugin5-no-latest-version", Version("3.0.0"), None),
-        Dependency("plugin6-invalid-ahead-current", Version("4.0.0"), Some(Version("3.0.1")))
+        Dependency("plugin1-up-to-date", "uk.gov.hmrc", Version("1.0.0"), Some(Version("1.0.0"))),
+        Dependency("plugin2-minor-behind", "uk.gov.hmrc", Version("2.0.0"), Some(Version("2.1.0"))),
+        Dependency("plugin3-major-behind", "uk.gov.hmrc", Version("3.0.0"), Some(Version("4.0.0"))),
+        Dependency("plugin4-patch-behind", "uk.gov.hmrc", Version("3.0.0"), Some(Version("3.0.1"))),
+        Dependency("plugin5-no-latest-version", "uk.gov.hmrc", Version("3.0.0"), None),
+        Dependency("plugin6-invalid-ahead-current", "uk.gov.hmrc", Version("4.0.0"), Some(Version("3.0.1")))
       ),
-      Seq(Dependency("sbt", Version("0.13.11"), Some(Version("0.13.15")))),
+      Seq(Dependency("sbt", "uk.gov.hmrc", Version("0.13.11"), Some(Version("0.13.15")))),
       lastUpdated = Instant.now
     )
 
@@ -182,7 +182,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
           "service",
           Nil,
           Nil,
-          Seq(Dependency("sbt", Version("1.0.0"), Some(Version("1.0.0")))),
+          Seq(Dependency("sbt", "org.scala-sbt", Version("1.0.0"), Some(Version("1.0.0")))),
           lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
 
@@ -197,7 +197,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
           "service",
           Nil,
           Nil,
-          Seq(Dependency("sbt", Version("1.0.0"), Some(Version("1.1.0")))),
+          Seq(Dependency("sbt", "org.scala-sbt", Version("1.0.0"), Some(Version("1.1.0")))),
           lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
 
@@ -213,7 +213,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
           "service",
           Nil,
           Nil,
-          Seq(Dependency("sbt", Version("1.0.0"), Some(Version("1.0.1")))),
+          Seq(Dependency("sbt", "org.scala-sbt", Version("1.0.0"), Some(Version("1.0.1")))),
           lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
 
@@ -229,7 +229,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
           "service",
           Nil,
           Nil,
-          Seq(Dependency("sbt", Version("1.0.0"), Some(Version("2.0.0")))),
+          Seq(Dependency("sbt", "org.scala-sbt", Version("1.0.0"), Some(Version("2.0.0")))),
           lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
 
@@ -244,7 +244,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
         "service",
         Nil,
         Nil,
-        Seq(Dependency("sbt", Version("1.0.0"), None)),
+        Seq(Dependency("sbt", "org.scala-sbt", Version("1.0.0"), None)),
         lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
 
@@ -260,7 +260,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
           "service",
           Nil,
           Nil,
-          Seq(Dependency("sbt", Version("5.0.0"), Some(Version("1.0.0")))),
+          Seq(Dependency("sbt", "org.scala-sbt", Version("5.0.0"), Some(Version("1.0.0")))),
           lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
 
@@ -273,7 +273,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
     "be shown if least one library dependency entry exists" in {
       val dependencies = Dependencies(
         "service",
-        Seq(Dependency("lib1-up-to-date", Version("1.0.0"), Some(Version("1.0.0")))),
+        Seq(Dependency("lib1-up-to-date", "uk.gov.hrmc", Version("1.0.0"), Some(Version("1.0.0")))),
         Nil,
         Nil,
         lastUpdated = Instant.now)
@@ -286,7 +286,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
       val dependencies = Dependencies(
         "service",
         Nil,
-        Seq(Dependency("plugin1-up-to-date", Version("1.0.0"), Some(Version("1.0.0")))),
+        Seq(Dependency("plugin1-up-to-date", "uk.gov.hrmc", Version("1.0.0"), Some(Version("1.0.0")))),
         Nil,
         lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
@@ -299,7 +299,7 @@ class DependenciesSpec extends WordSpec with MockitoSugar {
         "service",
         Nil,
         Nil,
-        Seq(Dependency("sbt", Version("1.0.0"), None)),
+        Seq(Dependency("sbt", "org.scala-sbt", Version("1.0.0"), None)),
         lastUpdated = Instant.now)
       val document = asDocument(new DependenciesPartial(viewMessages)(Some(dependencies)))
 

--- a/test/view/partials/DependencySectionSpec.scala
+++ b/test/view/partials/DependencySectionSpec.scala
@@ -21,8 +21,8 @@ import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependency, Version}
 
 class DependencySectionSpec extends WordSpec with Matchers {
 
-  val dependency1 = Dependency("example-library", Version("1.2.3-play-25"), Some(Version("1.2.3-play-26")))
-  val dependency2 = Dependency("library4j", Version("4.0.1"), Some(Version("4.2.0")))
+  val dependency1 = Dependency("example-library", "uk.gov.hmrc", Version("1.2.3-play-25"), Some(Version("1.2.3-play-26")))
+  val dependency2 = Dependency("library4j", "uk.gov.hmrc", Version("4.0.1"), Some(Version("4.2.0")))
 
   "dependency_section" should {
 
@@ -31,9 +31,9 @@ class DependencySectionSpec extends WordSpec with Matchers {
       res should include("""<span id="example-library-current-version" class="col-xs-3">1.2.3-play-25</span>""")
       res should include(
         """<span id="example-library-latestVersion-version" class="col-xs-3">
-        |                    <span class="glyphicon glyphicon-arrow-right small-glyphicon" style="padding-right: 10px;"> </span>
-        |                    1.2.3-play-26
-        |                </span>""".stripMargin)
+        |              <span class="glyphicon glyphicon-arrow-right small-glyphicon" style="padding-right: 10px;"> </span>
+        |              1.2.3-play-26
+        |          </span>""".stripMargin)
     }
 
     "not display the version suffix when missing" in {
@@ -41,10 +41,9 @@ class DependencySectionSpec extends WordSpec with Matchers {
       res should include("""<span id="library4j-current-version" class="col-xs-3">4.0.1</span>""")
       res should include(
         """<span id="library4j-latestVersion-version" class="col-xs-3">
-        |                    <span class="glyphicon glyphicon-arrow-right small-glyphicon" style="padding-right: 10px;"> </span>
-        |                    4.2.0
-        |                </span>""".stripMargin)
+        |              <span class="glyphicon glyphicon-arrow-right small-glyphicon" style="padding-right: 10px;"> </span>
+        |              4.2.0
+        |          </span>""".stripMargin)
     }
   }
-
 }


### PR DESCRIPTION
Now that service-dependencies returns the group of a dependency, we can correct the link to the bobby rule by taking this into account.
Further, if there is more than one bobby rule for the given dependency, we pick one to link to by choosing the latest upper bound. This is consistent with `sbt-bobby`.