### PR TITLE
BDOG-591 add ECS deployments to deployments page

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/BobbyRulesTrendController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/BobbyRulesTrendController.scala
@@ -22,7 +22,6 @@ import cats.data.EitherT
 import cats.instances.future._
 import javax.inject.{Inject, Singleton}
 import play.api.data.{Form, Forms}
-import play.api.i18n.MessagesProvider
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyVersionRange
 import uk.gov.hmrc.cataloguefrontend.connector.{ConfigConnector, ServiceDependenciesConnector}
@@ -109,7 +108,7 @@ class BobbyRulesTrendController @Inject()(
       rules: Seq[String]
     )
 
-  def form(implicit messagesProvider: MessagesProvider) = {
+  def form() = {
     import uk.gov.hmrc.cataloguefrontend.util.FormUtils.notEmptySeq
     Form(
       Forms.mapping(

--- a/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
@@ -21,8 +21,8 @@ import java.time.LocalDateTime
 import cats.implicits._
 import javax.inject.{Inject, Singleton}
 import play.api.Configuration
+import play.api.data.Form
 import play.api.data.Forms._
-import play.api.data.{Form, Mapping}
 import play.api.libs.json.Json.toJson
 import play.api.mvc._
 import uk.gov.hmrc.cataloguefrontend.DisplayableTeamMember._
@@ -473,15 +473,6 @@ object DigitalServiceNameFilter {
   )
 }
 
-case class DeploymentsFilter(
-  team: Option[String]        = None,
-  serviceName: Option[String] = None,
-  from: Option[LocalDateTime] = None,
-  to: Option[LocalDateTime]   = None
-) {
-  def isEmpty: Boolean = team.isEmpty && serviceName.isEmpty && from.isEmpty && to.isEmpty
-}
-
 case class RepoListFilter(
   name: Option[String]     = None,
   repoType: Option[String] = None
@@ -496,21 +487,4 @@ object RepoListFilter {
       "type" -> optional(text).transform[Option[String]](_.filter(_.trim.nonEmpty), identity)
     )(RepoListFilter.apply)(RepoListFilter.unapply)
   )
-}
-
-object DeploymentsFilter {
-  lazy val form = Form(
-    mapping(
-      "team"        -> optional(text).transform[Option[String]](_.filter(_.trim.nonEmpty), identity),
-      "serviceName" -> optional(text).transform[Option[String]](_.filter(_.trim.nonEmpty), identity),
-      "from"        -> optionalLocalDateTimeMapping("from.error.date"),
-      "to"          -> optionalLocalDateTimeMapping("to.error.date")
-    )(DeploymentsFilter.apply)(DeploymentsFilter.unapply)
-  )
-
-  def optionalLocalDateTimeMapping(errorCode: String): Mapping[Option[LocalDateTime]] = {
-    import DateHelper._
-    optional(text.verifying(errorCode, x => stringToLocalDateTimeOpt(x).isDefined))
-      .transform[Option[LocalDateTime]](_.flatMap(stringToLocalDateTimeOpt), _.map(_.format(`yyyy-MM-dd`)))
-  }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/DateHelper.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/DateHelper.scala
@@ -43,6 +43,10 @@ object DateHelper {
 
     def asString = d.format(DateTimeFormatter.ofPattern("dd-MM-yyyy HH:mm"))
 
+    def asUTCString = {
+      d.atZone(ZoneId.of("UTC")).format(`yyyy-MM-dd HH:mm:ss z`)
+    }
+
     def asPattern(pattern: String) = d.format(DateTimeFormatter.ofPattern(pattern))
 
     def asRFC1123: String =

--- a/app/uk/gov/hmrc/cataloguefrontend/DependencyExplorerController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/DependencyExplorerController.scala
@@ -23,7 +23,6 @@ import cats.instances.all._
 import javax.inject.{Inject, Singleton}
 import play.api.data.{Form, Forms}
 import play.api.http.HttpEntity
-import play.api.i18n.MessagesProvider
 import play.api.mvc._
 import uk.gov.hmrc.cataloguefrontend.connector.model.{BobbyVersionRange, ServiceWithDependency, TeamName, Version}
 import uk.gov.hmrc.cataloguefrontend.connector.TeamsAndRepositoriesConnector
@@ -167,7 +166,7 @@ class DependencyExplorerController @Inject()(
     , asCsv       : Boolean = false
     )
 
-  def form(implicit messagesProvider: MessagesProvider) = {
+  def form() = {
     import uk.gov.hmrc.cataloguefrontend.util.FormUtils.notEmpty
     Form(
       Forms.mapping(

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/model/Dependencies.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/model/Dependencies.scala
@@ -21,6 +21,7 @@ import java.time.{Instant, LocalDate}
 import com.github.ghik.silencer.silent
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
+import uk.gov.hmrc.http.controllers.RestFormats
 
 sealed trait VersionState
 object VersionState {

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/model/Dependencies.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/model/Dependencies.scala
@@ -21,7 +21,6 @@ import java.time.{Instant, LocalDate}
 import com.github.ghik.silencer.silent
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
-import uk.gov.hmrc.http.controllers.RestFormats
 
 sealed trait VersionState
 object VersionState {

--- a/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterWizardController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/shuttering/ShutterWizardController.scala
@@ -21,7 +21,7 @@ import cats.instances.all._
 import cats.syntax.all._
 import javax.inject.{Inject, Singleton}
 import play.api.data.{Form, Forms}
-import play.api.i18n.{Messages, MessagesProvider}
+import play.api.i18n.Messages
 import play.api.libs.json.Json
 import play.api.mvc.{MessagesControllerComponents, Request, Result}
 import play.twirl.api.Html
@@ -482,7 +482,7 @@ object ShutterWizardController {
 
   val step1Key  = DataKey[Step1Out]("step1")
 
-  def step1Form(implicit messagesProvider: MessagesProvider) =
+  def step1Form() =
     Form(
       Forms.mapping(
         "serviceName" -> Forms.seq(Forms.text).verifying(notEmptySeq),
@@ -509,7 +509,7 @@ object ShutterWizardController {
 
   val step2aKey = DataKey[Step2aOut]("step2a")
 
-  def step2aForm(implicit messagesProvider: MessagesProvider) =
+  def step2aForm() =
     Form(
       Forms
         .mapping(
@@ -531,7 +531,7 @@ object ShutterWizardController {
 
   val step2bKey = DataKey[Step2bOut]("step2b")
 
-  def step2bForm(implicit messagesProvider: MessagesProvider) =
+  def step2bForm() =
     Form(
       Forms.mapping(
           "reason"                -> Forms.text
@@ -560,7 +560,7 @@ object ShutterWizardController {
 
   // -- Step 3 -------------------------
 
-  def step3Form(implicit messagesProvider: MessagesProvider) =
+  def step3Form() =
     Form(
       Forms
         .mapping(

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentHistoryController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentHistoryController.scala
@@ -20,7 +20,6 @@ import java.time.{Instant, LocalDate, ZoneId}
 
 import javax.inject.{Inject, Singleton}
 import play.api.data.{Form, Forms}
-import play.api.i18n.MessagesProvider
 import play.api.mvc._
 import uk.gov.hmrc.cataloguefrontend.connector.TeamsAndRepositoriesConnector
 import uk.gov.hmrc.http.HeaderCarrier
@@ -51,7 +50,7 @@ class DeploymentHistoryController @Inject()(
 
   case class SearchForm(from: Option[Long], to: Option[Long], team: Option[String], app: Option[String])
 
-  def form(implicit messagesProvider: MessagesProvider): Form[SearchForm] = {
+  def form(): Form[SearchForm] = {
     val dateFormat = "yyyy-MM-dd"
     Form(
       Forms.mapping(

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentHistoryController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentHistoryController.scala
@@ -58,7 +58,8 @@ class DeploymentHistoryController @Inject()(
 
     for {
       deployments <- Future.sequence(
-        platforms.map(p => releasesConnector.deploymentHistory(p, env, from = search.from, to = search.to, app = search.app, team = search.team))
+        // We always search with App=None to pull back the whole set for filtering
+        platforms.map(p => releasesConnector.deploymentHistory(p, env, from = search.from, to = search.to, app = None, team = search.team))
       ).map(_.flatten)
       teams   <- teamsAndRepositoriesConnector.allTeams
     } yield Ok(
@@ -72,7 +73,7 @@ class DeploymentHistoryController @Inject()(
     )
   }
 
-  case class SearchForm(from: Option[Long], to: Option[Long], team: Option[String], app: Option[String], platform: Option[String])
+  case class SearchForm(from: Option[Long], to: Option[Long], team: Option[String], search: Option[String], platform: Option[String])
 
   val utc = ZoneId.of("UTC")
   def toLocalDate(l: Long): LocalDate = Instant.ofEpochMilli(l).atZone(ZoneId.of("UTC")).toLocalDate
@@ -93,7 +94,7 @@ class DeploymentHistoryController @Inject()(
             .localDate(dateFormat)
             .transform[Long](toEpochMillis(_, startOfDay = false), toLocalDate)),
         "team" -> Forms.optional(Forms.text),
-        "service" -> Forms.optional(Forms.text),
+        "search" -> Forms.optional(Forms.text),
         "platform" -> Forms.optional(Forms.text)
       )(SearchForm.apply)(SearchForm.unapply)
     )

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentHistoryController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentHistoryController.scala
@@ -61,7 +61,6 @@ class DeploymentHistoryController @Inject()(
         platforms.map(p => releasesConnector.deploymentHistory(p, env, from = search.from, to = search.to, app = search.app, team = search.team))
       ).map(_.flatten)
       teams   <- teamsAndRepositoriesConnector.allTeams
-
     } yield Ok(
       page(
         env,

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/FuturePlatformMigrationController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/FuturePlatformMigrationController.scala
@@ -18,10 +18,8 @@ package uk.gov.hmrc.cataloguefrontend.whatsrunningwhere
 
 import javax.inject.{Inject, Singleton}
 import play.api.mvc.MessagesControllerComponents
-import uk.gov.hmrc.cataloguefrontend.model.Environment
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.whatsrunningwhere.FuturePlatformMigrationPage
-import cats.implicits._
 
 import scala.collection.immutable.SortedMap
 import scala.concurrent.ExecutionContext

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnector.scala
@@ -91,6 +91,7 @@ class ReleasesConnector @Inject()(
 
   def deploymentHistory(
     platform: Platform,
+    environment: Environment,
     from: Option[Long]   = None,
     to: Option[Long]     = None,
     team: Option[String] = None,
@@ -101,7 +102,7 @@ class ReleasesConnector @Inject()(
 
     implicit val rf = JsonCodecs.heritageDeploymentReads
     http.GET[Seq[Deployment]](
-      url = s"$serviceUrl/releases-api/deployments/${Environment.Production.asString}",
+      url = s"$serviceUrl/releases-api/deployments/${environment.asString}",
       queryParams = UrlUtils.buildQueryParams(
         "from" -> from.map(_.toString),
         "to" -> to.map(_.toString),

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnector.scala
@@ -90,21 +90,24 @@ class ReleasesConnector @Inject()(
   }
 
   def deploymentHistory(
+    platform: Platform,
     from: Option[Long]   = None,
     to: Option[Long]     = None,
     team: Option[String] = None,
-    app: Option[String]  = None
-  )(
-    implicit
-    hc: HeaderCarrier): Future[Seq[HeritageDeployment]] = {
-    implicit val hdr = JsonCodecs.heritageDeploymentReads
-    http.GET[Seq[HeritageDeployment]](
+    app : Option[String] = None
+  )(implicit
+    hc: HeaderCarrier
+  ): Future[Seq[Deployment]] = {
+
+    implicit val rf = JsonCodecs.heritageDeploymentReads
+    http.GET[Seq[Deployment]](
       url = s"$serviceUrl/releases-api/deployments/${Environment.Production.asString}",
       queryParams = UrlUtils.buildQueryParams(
         "from" -> from.map(_.toString),
-        "to"   -> to.map(_.toString),
+        "to" -> to.map(_.toString),
         "team" -> team,
-        "app"  -> app
+        "app" -> app,
+        "platform" -> Some(platform.asString)
       )
     )
   }

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -14,13 +14,13 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.HeritageDeployment
+@import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.Deployment
 @import uk.gov.hmrc.cataloguefrontend.connector.Team
 @import uk.gov.hmrc.cataloguefrontend.DateHelper._
 @this()
 
 
-@(deployments: Seq[HeritageDeployment], teams: Seq[Team], userProfileBaseUrl: String)(implicit request: Request[_])
+@(deployments: Seq[Deployment], teams: Seq[Team], userProfileBaseUrl: String)(implicit request: Request[_])
 
 @standard_layout("Deployments", "deployments") {
   <header>
@@ -28,52 +28,53 @@
   </header>
 
  <div class="row">
-
      <div class="col-sm-12">
+          <form onsubmit="return updateDeployments()" class="form-inline" id="search-form">
+            <span>Service: <input id="service-search-input" type="text" name="app" value=''></span>
+            <span>Team:
+                <select name="team">
+                    <option value=""></option>
+                    @teams.map { t => <option value="@t.name.asString">@t.name.asString</option> }
+                </select>
+            </span>
 
-  <form onsubmit="return updateDeployments()" class="form-inline" id="search-form">
-    <span>Service: <input id="service-search-input" type="text" name="app" value=''></span>
-    <span>Team:
-        <select name="team">
-            <option value=""></option>
-@teams.map { t => <option value="@t.name.asString">@t.name.asString</option> }
-     </select>
+            <div class="input-group">
+              Deployment from: <input id="from-search-input" type="date" name="from" value=''>
+              to:<input type="date" id="to-search-input" name="to" value=''>
+            </div>
 
-</span>
+            <input type="submit" value="Filter">
 
-    <div class="input-group">
-      Deployment from: <input id="from-search-input" type="date" name="from" value=''>
-      to:<input type="date" id="to-search-input" name="to" value=''>
+          </form>
     </div>
-    <input type="submit" value="Filter">
-  </form>
 </div>
-</div>
+
 <div class="row">
   <table class="table table-striped">
     <tr>
       <th><span>Service</span></th>
       <th><span>Teams</span></th>
       <th><span>Version</span></th>
-      <th><span>Production deployment</span></th>
-      <th><span>Latest Deployer</span></th>
+      <th><span>Deploy Time</span></th>
+      <th><span>Deployer</span></th>
     </tr>
-    @deployments.zipWithIndex.map{case (release, i) =>
+    @deployments.zipWithIndex.map{case (d, i) =>
     <tr id="row@i">
-      <td id="row@{i}_name"><a
-      href="@{uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(release.name.asString).url}">@{release.name.asString}</a>
+      <td id="row@{i}_name">
+          @if(d.isECS){ <span class="label label-primary pull-right">ECS</span>}
+          <a href="@{uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(d.name.asString).url}">@{d.name.asString}</a>
       </td>
       <td id="row@{i}_team">
         <ul class="list-group">
-        @for(team <- release.teams) {
+        @for(team <- d.teams) {
           <li ><a href="@{uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.team(team).url}">@{team.asString}</a></li>
         }
         </ul>
       </td>
-      <td class="monospaced" id="row@{i}_version">@{release.version.asString}</td>
-      <td class="monospaced" id="row@{i}_production">@{release.productionDate.time.asString}</td>
+      <td class="monospaced" id="row@{i}_version">@{d.version.asString}</td>
+      <td class="monospaced" id="row@{i}_production">@{d.firstSeen.time.asString}</td>
       <td class="monospaced" id="row@{i}_deployer">
-      @release.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
+      @d.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
       </td>
     </tr>
     }

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -57,7 +57,6 @@
       <th><span>Version</span></th>
       <th><span>Production deployment</span></th>
       <th><span>Latest Deployer</span></th>
-      <th>Interval</th>
     </tr>
     @deployments.zipWithIndex.map{case (release, i) =>
     <tr id="row@i">
@@ -76,7 +75,6 @@
       <td class="monospaced" id="row@{i}_deployer">
       @release.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
       </td>
-      <td class="monospaced" id="row@{i}_interval">@{release.interval.fold("--")(x => if(x.toDays==1) "1 day" else s"${x.toDays} days")}</td>
     </tr>
     }
 

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -34,12 +34,13 @@
         <h1>Deployments</h1>
     </header>
 
-    <div id="service-list">
-        <form method="get">
+    <div id="search-list">
+        <form id="form">
             <div class="form-group row">
+                <input type="hidden" id="selected-environment" value="@selectedEnv.asString">
                 <div class="col-xs-3">
-                    <label for="service-search-input" title="Search across all fields" data-toggle="tooltip">Search</label>
-                    <input id="service-search-input" class="search form-control" type="text" name="service" value='@form("service").value' autofocus>
+                    <label for="search" title="Search across all fields" data-toggle="tooltip">Search</label>
+                    <input id="search" class="search form-control" type="text" name="search" value='@form("search").value' autofocus>
                 </div>
                 <div class="col-xs-2">
                     @select(
@@ -115,14 +116,28 @@
     </div>
 }
 
-<!-- listjs configuration -->
 <script>
+// listjs configuration
 var options = { valueNames: [ 'service-name','team', 'version', 'deploy-time', 'deployer' ] };
-var serviceList = new List('service-list', options);
+var serviceList = new List('search-list', options);
+
+// re-search the list upon page load.
+serviceList.search($('#search').val());
+
+function selectEnvironment(e, environment) {
+  // Stop the default link action. Instead we will fire the form to change page
+  e.preventDefault();
+
+  // Update the hidden environment field with what was selected
+  $('#selected-environment').value = environment;
+
+  // Post the form back to the the chosen environment endpoint
+  $('#form').attr('action', "/deployments/" + environment).submit();
+};
 </script>
 
 @envOption(env: Environment) = {
 <li id="tab-@env.asString" class="navbar-item @if(env == selectedEnv){active}">
-    <a href="@uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.routes.DeploymentHistoryController.history(env)" class="navbar-link">@env.displayString</a>
+    <a href="/deployments/@{env.asString}" class="navbar-link" id="@{env.asString}-tab" onclick="javascript:selectEnvironment(event, '@{env.asString}')" role="tab">@env.displayString</a>
 </li>
 }

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -38,7 +38,7 @@
         <form method="get">
             <div class="form-group row">
                 <div class="col-xs-3">
-                    <label for="service-search-input">Service name</label>
+                    <label for="service-search-input" title="Search across all fields" data-toggle="tooltip">Search</label>
                     <input id="service-search-input" class="search form-control" type="text" name="service" value='@form("service").value' autofocus>
                 </div>
                 <div class="col-xs-2">
@@ -65,11 +65,11 @@
                     )
                 </div>
                 <div class="col-xs-2">
-                    <label for="from-search-input">Date From</label>
+                    <label for="from-search-input" title="From the start of this day" data-toggle="tooltip">Date From</label>
                     <input id="from-search-input" class="form-control" type="date" name="from" onchange="this.form.submit()" value='@form("from").value'>
                 </div>
                 <div class="col-xs-2">
-                    <label for="to-search-input">Date To</label>
+                    <label for="to-search-input" title="To the end of this day" data-toggle="tooltip" >Date To</label>
                     <input id="to-search-input" class="form-control" type="date" name="to" onchange="this.form.submit()" value='@form("to").value'>
                 </div>
             </div>

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -16,15 +16,16 @@
 
 @import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.Deployment
 @import uk.gov.hmrc.cataloguefrontend.connector.Team
+@import uk.gov.hmrc.cataloguefrontend.model.Environment
 @import uk.gov.hmrc.cataloguefrontend.DateHelper._
 @this()
 
 
-@(deployments: Seq[Deployment], teams: Seq[Team], userProfileBaseUrl: String)(implicit request: Request[_])
+@(env: Environment, deployments: Seq[Deployment], teams: Seq[Team], userProfileBaseUrl: String)(implicit request: Request[_])
 
 @standard_layout("Deployments", "deployments") {
   <header>
-    <h1>Deployments: Production</h1>
+    <h1>Deployments: @env.asString</h1>
   </header>
 
  <div class="row">

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -44,7 +44,7 @@
     </div>
     }
 
-    <div id="search-list">
+    <div id="service-list">
         <form id="form">
             <div class="form-group row">
                 <input type="hidden" id="selected-environment" value="@selectedEnv.asString">
@@ -129,7 +129,7 @@
 <script>
 // listjs configuration
 var options = { valueNames: [ 'service-name','team', 'version', 'deploy-time', 'deployer' ] };
-var serviceList = new List('search-list', options);
+var serviceList = new List('service-list', options);
 
 var searchBox = document.getElementById("search");
 

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -31,42 +31,48 @@
 
 @standard_layout("Deployments", "deployments") {
     <header>
-        <h1>Deployments: @selectedEnv.asString</h1>
+        <h1>Deployments</h1>
     </header>
 
     <div id="service-list">
         <form method="get">
             <div class="form-group row">
-            <span>Service: <input id="service-search-input" type="text" name="service" value='@form("service").value'></span>
-             @select(
-                 field = form("platform"),
-                 options = Seq(
-                     "Heritage" -> "Heritage",
-                     "ECS" -> "ECS"
-                 ),
-                 '_default -> "All",
-                 '_label -> "Platform",
-                 'onchange -> "this.form.submit()",
-                 'id -> "platform-search"
-             )
-             @select(
-                 field = form("team"),
-                 options = teams.map(t => t.name.asString -> t.name.asString),
-                 '_default -> "All",
-                 '_label -> "Team",
-                 'onchange -> "this.form.submit()",
-                 'id -> "team-search"
-             )
-         </div>
-
-            <div class="form-group row">
-            <div class="input-group">
-                Date from: <input id="from-search-input" type="date" name="from" value='@form("from").value'>
-                to:<input type="date" id="to-search-input" name="to" value='@form("to").value'>
+                <div class="col-xs-3">
+                    <label for="service-search-input">Service name</label>
+                    <input id="service-search-input" class="search form-control" type="text" name="service" value='@form("service").value' autofocus>
+                </div>
+                <div class="col-xs-2">
+                    @select(
+                        field = form("platform"),
+                        options = Seq(
+                        "Heritage" -> "Heritage",
+                        "ECS" -> "ECS"
+                        ),
+                        '_default -> "All",
+                        '_label -> "Platform",
+                        'onchange -> "this.form.submit()",
+                        'id -> "platform-search"
+                    )
+                </div>
+                <div class="col-xs-3">
+                    @select(
+                        field = form("team"),
+                        options = teams.map(t => t.name.asString -> t.name.asString),
+                        '_default -> "All",
+                        '_label -> "Team",
+                        'onchange -> "this.form.submit()",
+                        'id -> "team-search"
+                    )
+                </div>
+                <div class="col-xs-2">
+                    <label for="from-search-input">Date From</label>
+                    <input id="from-search-input" class="form-control" type="date" name="from" onchange="this.form.submit()" value='@form("from").value'>
+                </div>
+                <div class="col-xs-2">
+                    <label for="to-search-input">Date From</label>
+                    <input type="date" id="to-search-input" class="form-control" name="to" onchange="this.form.submit()" value='@form("to").value'>
+                </div>
             </div>
-
-            <input type="submit" value="Filter">
-        </div>
         </form>
 
         <div class="row">

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -77,11 +77,11 @@
                 </div>
                 <div class="col-xs-2">
                     <label for="from-search-input" title="From the start of this day" data-toggle="tooltip">Date From</label>
-                    <input id="from-search-input" class="form-control" type="date" name="from" onchange="this.form.submit()" value='@form("from").value'>
+                    <input id="from-search-input" class="form-control" type="date" name="from" onchange="dateFilterChange(event)" value='@form("from").value'>
                 </div>
                 <div class="col-xs-2">
                     <label for="to-search-input" title="To the end of this day" data-toggle="tooltip" >Date To</label>
-                    <input id="to-search-input" class="form-control" type="date" name="to" onchange="this.form.submit()" value='@form("to").value'>
+                    <input id="to-search-input" class="form-control" type="date" name="to" onchange="dateFilterChange(event)" value='@form("to").value'>
                 </div>
             </div>
         </form>
@@ -116,8 +116,7 @@
                   </td>
                   <td id="row@{i}_version"    class="version">@{d.version.asString}</td>
                   <td id="row@{i}_deploytime" class="deploy-time monospaced">@{d.firstSeen.time.asUTCString}</td>
-                  <td id="row@{i}_deployer"   class="deployer">
-                    @d.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
+                  <td id="row@{i}_deployer"   class="deployer">@d.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
                   </td>
                 </tr>
                 }
@@ -140,6 +139,13 @@ serviceList.search(search.value);
 var length = searchBox.value.length;
 searchBox.focus();
 searchBox.setSelectionRange(length, length);
+
+function dateFilterChange(e) {
+    // Wait a bit before submitting to allow acceptance tests to fill complete field
+    setTimeout( function () {
+        $('#form').submit();
+    }, 100);
+}
 
 function selectEnvironment(e, environment) {
   // Stop the default link action. Instead we will fire the form to change page

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -18,36 +18,60 @@
 @import uk.gov.hmrc.cataloguefrontend.connector.Team
 @import uk.gov.hmrc.cataloguefrontend.model.Environment
 @import uk.gov.hmrc.cataloguefrontend.DateHelper._
+@import helper._
 @this()
 
-
-@(env: Environment, deployments: Seq[Deployment], teams: Seq[Team], userProfileBaseUrl: String)(implicit request: Request[_])
+@(
+    selectedEnv: Environment, deployments: Seq[Deployment],
+    teams: Seq[Team],
+    userProfileBaseUrl: String,
+    form: Form[_]
+)(implicit messages: Messages, request: Request[_])
 
 @standard_layout("Deployments", "deployments") {
   <header>
-    <h1>Deployments: @env.asString</h1>
+    <h1>Deployments: @selectedEnv.asString</h1>
   </header>
 
- <div class="row">
-     <div class="col-sm-12">
-          <form onsubmit="return updateDeployments()" class="form-inline" id="search-form">
-            <span>Service: <input id="service-search-input" type="text" name="app" value=''></span>
-            <span>Team:
-                <select name="team">
-                    <option value=""></option>
-                    @teams.map { t => <option value="@t.name.asString">@t.name.asString</option> }
-                </select>
-            </span>
+     <form class="form-inline" id="search-form">
 
+        <div class="row">
+            <span>Service: <input id="service-search-input" type="text" name="service" value='@form("service").value'></span>
+             @select(
+                 field = form("platform"),
+                 options = Seq(
+                     "Heritage" -> "Heritage",
+                     "ECS" -> "ECS"
+                 ),
+                 '_default -> "All",
+                 '_label -> "Platform",
+                 'onchange -> "this.form.submit()",
+                 'id -> "platform-search"
+             )
+             @select(
+                 field = form("team"),
+                 options = teams.map(t => t.name.asString -> t.name.asString),
+                 '_default -> "All",
+                 '_label -> "Team",
+                 'onchange -> "this.form.submit()",
+                 'id -> "team-search"
+             )
+         </div>
+
+        <div class="row">
             <div class="input-group">
-              Deployment from: <input id="from-search-input" type="date" name="from" value=''>
-              to:<input type="date" id="to-search-input" name="to" value=''>
+                Date from: <input id="from-search-input" type="date" name="from" value='@form("from").value'>
+                to:<input type="date" id="to-search-input" name="to" value='@form("to").value'>
             </div>
 
             <input type="submit" value="Filter">
+        </div>
+     </form>
 
-          </form>
-    </div>
+<div class="row">
+    <ul id="environment" class="nav nav-tabs">
+        @Environment.values.map(envOption)
+    </ul>
 </div>
 
 <div class="row">
@@ -82,4 +106,10 @@
 
   </table>
 </div>
+}
+
+@envOption(env: Environment) = {
+<li id="tab-@env.asString" class="navbar-item @if(env == selectedEnv){active}">
+    <a href="@uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.routes.DeploymentHistoryController.history(env)" class="navbar-link">@env.displayString</a>
+</li>
 }

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -19,6 +19,7 @@
 @import uk.gov.hmrc.cataloguefrontend.model.Environment
 @import uk.gov.hmrc.cataloguefrontend.DateHelper._
 @import helper._
+
 @this()
 
 @(
@@ -29,13 +30,13 @@
 )(implicit messages: Messages, request: Request[_])
 
 @standard_layout("Deployments", "deployments") {
-  <header>
-    <h1>Deployments: @selectedEnv.asString</h1>
-  </header>
+    <header>
+        <h1>Deployments: @selectedEnv.asString</h1>
+    </header>
 
-     <form class="form-inline" id="search-form">
-
-        <div class="row">
+    <div id="service-list">
+        <form method="get">
+            <div class="form-group row">
             <span>Service: <input id="service-search-input" type="text" name="service" value='@form("service").value'></span>
              @select(
                  field = form("platform"),
@@ -58,7 +59,7 @@
              )
          </div>
 
-        <div class="row">
+            <div class="form-group row">
             <div class="input-group">
                 Date from: <input id="from-search-input" type="date" name="from" value='@form("from").value'>
                 to:<input type="date" id="to-search-input" name="to" value='@form("to").value'>
@@ -66,47 +67,53 @@
 
             <input type="submit" value="Filter">
         </div>
-     </form>
+        </form>
 
-<div class="row">
-    <ul id="environment" class="nav nav-tabs">
-        @Environment.values.map(envOption)
-    </ul>
-</div>
+        <div class="row">
+            <ul id="environment" class="nav nav-tabs">
+                @Environment.values.map(envOption)
+            </ul>
+        </div>
 
-<div class="row">
-  <table class="table table-striped">
-    <tr>
-      <th><span>Service</span></th>
-      <th><span>Teams</span></th>
-      <th><span>Version</span></th>
-      <th><span>Deploy Time</span></th>
-      <th><span>Deployer</span></th>
-    </tr>
-    @deployments.zipWithIndex.map{case (d, i) =>
-    <tr id="row@i">
-      <td id="row@{i}_name">
-          @if(d.isECS){ <span class="label label-primary pull-right">ECS</span>}
-          <a href="@{uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(d.name.asString).url}">@{d.name.asString}</a>
-      </td>
-      <td id="row@{i}_team">
-        <ul class="list-group">
-        @for(team <- d.teams) {
-          <li ><a href="@{uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.team(team).url}">@{team.asString}</a></li>
-        }
-        </ul>
-      </td>
-      <td class="monospaced" id="row@{i}_version">@{d.version.asString}</td>
-      <td class="monospaced" id="row@{i}_production">@{d.firstSeen.time.asString}</td>
-      <td class="monospaced" id="row@{i}_deployer">
-      @d.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
-      </td>
-    </tr>
-    }
-
-  </table>
-</div>
+        <table class="table table-striped">
+            <tr>
+                <th class="col-lg-4"><button role="button" class="sort no-border" data-sort="service-name">Service</button></th>
+                <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="team">Teams</button></th>
+                <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="version">Version</button></th>
+                <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="deploy-time">Deploy Time</button></th>
+                <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="deployer">Deployer</button></th>
+            </tr>
+            <tbody class="list">
+                @deployments.zipWithIndex.map{case (d, i) =>
+                <tr id="row@i">
+                  <td id="row@{i}_name" class="service-name">
+                      @if(d.isECS){ <span class="label label-primary pull-right">ECS</span>}
+                      <a href="@{uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(d.name.asString).url}">@{d.name.asString}</a>
+                  </td>
+                  <td id="row@{i}_team" class="team">
+                    <ul class="list-group">
+                    @for(team <- d.teams) {
+                      <li><a href="@{uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.team(team).url}">@{team.asString}</a></li>
+                    }
+                    </ul>
+                  </td>
+                  <td id="row@{i}_version"    class="version monospaced">@{d.version.asString}</td>
+                  <td id="row@{i}_production" class="deploy-time monospaced">@{d.firstSeen.time.asString}</td>
+                  <td id="row@{i}_deployer"   class="deployer monospaced">
+                    @d.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
+                  </td>
+                </tr>
+                }
+          </tbody>
+      </table>
+    </div>
 }
+
+<!-- listjs configuration -->
+<script>
+var options = { valueNames: [ 'service-name','team', 'version', 'deploy-time', 'deployer' ] };
+var serviceList = new List('service-list', options);
+</script>
 
 @envOption(env: Environment) = {
 <li id="tab-@env.asString" class="navbar-item @if(env == selectedEnv){active}">

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -131,8 +131,15 @@
 var options = { valueNames: [ 'service-name','team', 'version', 'deploy-time', 'deployer' ] };
 var serviceList = new List('search-list', options);
 
+var searchBox = document.getElementById("search");
+
 // re-search the list upon page load.
-serviceList.search($('#search').val());
+serviceList.search(search.value);
+
+// set autofocus cursor to right of text in search box
+var length = searchBox.value.length;
+searchBox.focus();
+searchBox.setSelectionRange(length, length);
 
 function selectEnvironment(e, environment) {
   // Stop the default link action. Instead we will fire the form to change page

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -34,6 +34,16 @@
         <h1>Deployments</h1>
     </header>
 
+    @if(form.hasErrors) {
+    <div class="alert alert-danger" role="alert">
+        <ul class="list">
+            @form.errors.map { error =>
+            <li class="alert-danger"> @Messages(error.message, error.args: _*)</li>
+            }
+        </ul>
+    </div>
+    }
+
     <div id="search-list">
         <form id="form">
             <div class="form-group row">

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -69,8 +69,8 @@
                     <input id="from-search-input" class="form-control" type="date" name="from" onchange="this.form.submit()" value='@form("from").value'>
                 </div>
                 <div class="col-xs-2">
-                    <label for="to-search-input">Date From</label>
-                    <input type="date" id="to-search-input" class="form-control" name="to" onchange="this.form.submit()" value='@form("to").value'>
+                    <label for="to-search-input">Date To</label>
+                    <input id="to-search-input" class="form-control" type="date" name="to" onchange="this.form.submit()" value='@form("to").value'>
                 </div>
             </div>
         </form>
@@ -83,10 +83,10 @@
 
         <table class="table table-striped">
             <tr>
-                <th class="col-lg-4"><button role="button" class="sort no-border" data-sort="service-name">Service</button></th>
+                <th class="col-lg-3"><button role="button" class="sort no-border" data-sort="service-name">Service</button></th>
                 <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="team">Teams</button></th>
                 <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="version">Version</button></th>
-                <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="deploy-time">Deploy Time</button></th>
+                <th class="col-lg-3"><button role="button" class="sort no-border" data-sort="deploy-time">Deploy Time</button></th>
                 <th class="col-lg-2"><button role="button" class="sort no-border" data-sort="deployer">Deployer</button></th>
             </tr>
             <tbody class="list">
@@ -103,9 +103,9 @@
                     }
                     </ul>
                   </td>
-                  <td id="row@{i}_version"    class="version monospaced">@{d.version.asString}</td>
-                  <td id="row@{i}_production" class="deploy-time monospaced">@{d.firstSeen.time.asString}</td>
-                  <td id="row@{i}_deployer"   class="deployer monospaced">
+                  <td id="row@{i}_version"    class="version">@{d.version.asString}</td>
+                  <td id="row@{i}_deploytime" class="deploy-time monospaced">@{d.firstSeen.time.asUTCString}</td>
+                  <td id="row@{i}_deployer"   class="deployer">
                     @d.latestDeployer.map{u =><a href="@userProfileBaseUrl/@{u.userName}" target="_blank">@{u.userName}<span class="glyphicon glyphicon-new-window"/></a>}.getOrElse("N/A")
                   </td>
                 </tr>

--- a/app/views/RepositoriesListPage.scala.html
+++ b/app/views/RepositoriesListPage.scala.html
@@ -33,49 +33,46 @@
         <h1>Repositories</h1>
     </header>
 
+    @if(form.hasErrors) {
+        <div class="alert alert-danger" role="alert">
+        <ul class="list">
+            @form.errors.map { error =>
+            <li class="alert-danger"> @Messages(error.message, error.args: _*)</li>
+            }
+        </ul>
+    </div>
+    }
 
-@if(form.hasErrors) {
-<div class="alert alert-danger" role="alert">
-    <ul class="list">
-        @form.errors.map { error =>
-        <li class="alert-danger"> @Messages(error.message, error.args: _*)</li>
-        }
-    </ul>
-</div>
-}
+    <div id="service-list">
+        <form action="/repositories" method="get">
+            <div class="form-group row">
+                <div class="col-xs-1 padding-reset-right">
+                    <label for="search">Name:</label>
+                </div>
+                <div class="col col-xs-3">
+                    <input class="search form-control" id="search" type="text" name="name" value='@form("name").value' autofocus>
+                </div>
+                <div class="col-xs-1 col-xs-offset-2">
+                    <label for="type-search">Type:</label>
+                </div>
 
-
-<div id="service-list">
-    <form action="/repositories" method="get">
-        <div class="form-group row">
-            <div class="col-xs-1 padding-reset-right">
-                <label for="search">Name:</label>
+                <div class="col col-xs-2">
+                    @select(
+                        field = form("type"),
+                        options = Seq(
+                            "Library" -> "Library",
+                            "Prototype" -> "Prototype",
+                            "Service" -> "Service",
+                            "Other" -> "Other"
+                        ),
+                        '_default -> "All",
+                        '_label -> "",
+                        'onchange -> "this.form.submit()",
+                        'id -> "type-search"
+                    )
             </div>
-            <div class="col col-xs-3">
-                <input class="search form-control" id="search" type="text" name="name" value="@form("name").value" autofocus>
             </div>
-            <div class="col-xs-1 col-xs-offset-2">
-                <label for="type-search">Type:</label>
-            </div>
-
-            <div class="col col-xs-2">
-                @select(
-                    field = form("type"),
-                    options = Seq(
-                        "Library" -> "Library",
-                        "Prototype" -> "Prototype",
-                        "Service" -> "Service",
-                        "Other" -> "Other"
-                    ),
-                    '_default -> "All",
-                    '_label -> "",
-                    'onchange -> "this.form.submit()",
-                    'id -> "type-search"
-            )
-            </div>
-        </div>
-    </form>
-
+        </form>
         <table class="table table-striped">
             <tr>
                 <th class="col-lg-6"><button role="button" class="sort no-border" data-sort="service-name">Name</button></th>
@@ -101,22 +98,17 @@
             </tr>
             }
             </tbody>
-
-
         </table>
-
     </div>
 }
 
-        <!-- listjs configuration -->
-    <script>
-        var options = { valueNames: [ 'service-name','repo-type', 'created', 'last-active' ] };
+<!-- listjs configuration -->
+<script>
+    var options = { valueNames: [ 'service-name','repo-type', 'created', 'last-active' ] };
+    var serviceList = new List('service-list', options);
+</script>
 
-        var serviceList = new List('service-list', options);
-    </script>
-
-
-    @repoTypes = @{
+@repoTypes = @{
     ("" ,"All") +: RepoType.values.map {v =>
         if (v == RepoType.Service) (v.toString, "Service")
         else (v.toString, v.toString)

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -152,7 +152,7 @@
             @usernameFor(state.lastEvent)
           </td>
           <td id="row@{i}_date" class="shutter-date">
-            @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
+            @state.lastEvent.map(e => e.timestamp.asUTC.toLocalDateTime.asUTCString).getOrElse("")
           </td>
           <td id="row@{i}_event">
             @if(state.lastEvent.isDefined) {

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -68,21 +68,19 @@
           </div>
       </div>
   }
-  <div class="row tabs-bottom">
+  <div id="service-list" class="row tabs-bottom">
       <table id="shutter-state-table" class="table table-striped">
-          <thead>
-              <tr>
-                  <th id="service-header"><p class="shutter-overview-header">Service</p></th>
-                  <th id="status-header"><p class="shutter-overview-header">Status</p></th>
-                  <th id="last-update-by-header"><p class="shutter-overview-header">Last updated by</p></th>
-                  <th id="date-header"><p class="shutter-overview-header">Date</p></th>
-                  <th id="events-link"><p class="shutter-overview-header">Events</p></th>
-                  @if(isSignedIn) { <th id="update-header"><p class="shutter-overview-header">Update</p></th> }
-              </tr>
-          </thead>
+          <tr>
+              <th id="service-header"><p class="shutter-overview-header"><button role="button" class="sort no-border" data-sort="shutter-service">Service</button></p></th>
+              <th id="status-header"><p class="shutter-overview-header"><button role="button" class="sort no-border" data-sort="shutter-state">Status</button></p></th>
+              <th id="last-update-by-header"><p class="shutter-overview-header"><button role="button" class="sort no-border" data-sort="shutter-user">Last Updated By</button></p></th>
+              <th id="date-header"><p class="shutter-overview-header"><button role="button" class="sort no-border" data-sort="shutter-date">Date</button></p></th>
+              <th id="events-link"><p class="shutter-overview-header">Events</p></th>
+              @if(isSignedIn) { <th id="update-header"><p class="shutter-overview-header">Update</p></th> }
+          </tr>
 
-          <tbody>
-              @shutterStates.get(selectedEnv).getOrElse(Seq.empty).map(shutterRow)
+          <tbody class="list">
+            @shutterRows(shutterStates.get(selectedEnv).getOrElse(Seq.empty))
           </tbody>
 
       </table>
@@ -105,6 +103,9 @@
             });
         }
     }
+
+    var options = { valueNames: [ 'shutter-service', 'shutter-state', 'shutter-user', 'shutter-date' ] };
+    var serviceList = new List('service-list', options);
   </script>
 }
 
@@ -136,42 +137,44 @@
   }
 }
 
-@shutterRow(state: ShutterStateData) = {
-  <tr class="shutter-row @classFor(state.status.value)">
-      <td class="shutter-service">
-        <a class="shutter-row-link" href="@uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(state.serviceName)">
-          @state.serviceName
-        </a>
-      </td>
-      <td class="shutter-state">
-        @state.status.value
-      </td>
-      <td class="shutter-user">
-        @usernameFor(state.lastEvent)
-      </td>
-      <td class="shutter-date">
-        @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
-      </td>
-      <td>
-        @if(state.lastEvent.isDefined) {
-          <a id="event-history-link-@{state.serviceName}-@{state.environment.asString}"
-             class="medium-glyphicon glyphicon glyphicon-list"
-             data-toggle="tooltip"
-             data-placement="right"
-             title="@messages("shutter-event.history")"
-             href="@routes.ShutterEventsController.shutterEventsList(state.environment, Some(state.serviceName))"></a>
-        } else {
-          @Html("No events")
-        }
-      </td>
-      @if(isSignedIn) {
-        <td class="shutter-update">
-          <a id="shutter-link" class="shutter-row-link" href="@routes.ShutterWizardController.start(state.shutterType, state.environment, Some(state.serviceName))">
-            @changeValueFor(state.status.value)
-          </a>
-        </td>
-      }
-  </tr>
+@shutterRows(states: Seq[ShutterStateData]) = {
+    @states.zipWithIndex.map{case (state, i) =>
+      <tr id="row@i" class="shutter-row @classFor(state.status.value)">
+          <td id="row@{i}_name" class="shutter-service">
+            <a class="shutter-row-link" href="@uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(state.serviceName)">
+              @state.serviceName
+            </a>
+          </td>
+          <td id="row@{i}_state" class="shutter-state">
+            @state.status.value
+          </td>
+          <td id="row@{i}_user" class="shutter-user">
+            @usernameFor(state.lastEvent)
+          </td>
+          <td id="row@{i}_date" class="shutter-date">
+            @state.lastEvent.map(e => e.timestamp.asUTC.format(`yyyy-MM-dd HH:mm:ss z`)).getOrElse("")
+          </td>
+          <td id="row@{i}_event">
+            @if(state.lastEvent.isDefined) {
+              <a id="event-history-link-@{state.serviceName}-@{state.environment.asString}"
+                 class="medium-glyphicon glyphicon glyphicon-list"
+                 data-toggle="tooltip"
+                 data-placement="right"
+                 title="@messages("shutter-event.history")"
+                 href="@routes.ShutterEventsController.shutterEventsList(state.environment, Some(state.serviceName))"></a>
+            } else {
+              @Html("No events")
+            }
+          </td>
+          @if(isSignedIn) {
+            <td id="row@{i}_update" class="shutter-update">
+              <a id="shutter-link" class="shutter-row-link" href="@routes.ShutterWizardController.start(state.shutterType, state.environment, Some(state.serviceName))">
+                @changeValueFor(state.status.value)
+              </a>
+            </td>
+          }
+      </tr>
+    }
 }
 
 @usernameFor(eventOpt: Option[ShutterStateChangeEvent]) = @{

--- a/app/views/standard_layout.scala.html
+++ b/app/views/standard_layout.scala.html
@@ -33,7 +33,7 @@
         <style>
 
         table .sort {
-            background-image: url(assets/img/listjs-arrow-sort-inactive.png);
+            background-image: url(/assets/img/listjs-arrow-sort-inactive.png);
             background-repeat: no-repeat;
             background-position: right center;
             padding-right: 24px;
@@ -41,7 +41,7 @@
             cursor: hand;
         }
         table .sort.asc {
-            background-image: url(assets/img/listjs-arrow-sort-active-down.png);
+            background-image: url(/assets/img/listjs-arrow-sort-active-down.png);
             background-repeat: no-repeat;
             background-position: right center;
             padding-right: 19px;
@@ -49,7 +49,7 @@
             cursor: hand;
         }
         table .sort.desc {
-            background-image: url(assets/img/listjs-arrow-sort-active-up.png);
+            background-image: url(/assets/img/listjs-arrow-sort-active-up.png);
             background-repeat: no-repeat;
             background-position: right center;
             padding-right: 19px;

--- a/app/views/standard_layout.scala.html
+++ b/app/views/standard_layout.scala.html
@@ -16,6 +16,7 @@
 
 @import uk.gov.hmrc.cataloguefrontend.{ routes => appRoutes }
 @import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterType
+@import uk.gov.hmrc.cataloguefrontend.model.Environment.Production
 
 @(title: String = "Home", active: String = "")(content: Html)(implicit request: Request[_])
 <!DOCTYPE html>
@@ -75,7 +76,7 @@
                         <a id="link-to-repositories" href="@appRoutes.CatalogueController.allRepositories" class="@if(active=="repositories") {active}">Repositories</a>
                     </li>
                     <li>
-                        <a id="link-to-deployments" href="@uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.routes.DeploymentHistoryController.history" class="@if(active=="deployments") {active}">Deployments</a>
+                        <a id="link-to-deployments" href="@uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.routes.DeploymentHistoryController.history(Production)" class="@if(active=="deployments") {active}">Deployments</a>
                     </li>
                     <li>
                         <a id="link-to-whats-running-where" href="@uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.routes.WhatsRunningWhereController.heritageReleases()" class="@if(active=="whats-running-where") {active}">What's Running Where</a>

--- a/app/views/standard_layout.scala.html
+++ b/app/views/standard_layout.scala.html
@@ -28,6 +28,7 @@
         <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/list.js/1.3.0/list.min.js"></script>
+        <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
         <script src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
         <style>
@@ -132,6 +133,11 @@
             })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
             ga('create', 'UA-43414424-19', { 'anonymizeIp': true });
             ga('send', 'pageview');
+
+            // Activate bootstrap tooltips
+            $(function () {
+                $('[data-toggle="tooltip"]').tooltip()
+            })
         </script>
     </body>
 </html>

--- a/app/views/whatsrunningwhere/WhatsRunningWherePage.scala.html
+++ b/app/views/whatsrunningwhere/WhatsRunningWherePage.scala.html
@@ -53,7 +53,7 @@
                 </div>
                 <div class="col col-xs-3">
                     <input class="search form-control" id="search" type="text" name="application_name"
-                    value="@form("application_name").value" autofocus>
+                    value='@form("application_name").value' autofocus>
                 </div>
             </div>
             <div class="form-group row">
@@ -74,7 +74,7 @@
 
         <table class="table table-striped" id="service-list">
             <thead>
-                <th>Application name</th>
+                <th><button role="button" class="sort no-border" data-sort="application-name">Application Name</button></th>
                 @environments.map { env =>
                     <th>@env.displayString</th>
                 }
@@ -102,7 +102,7 @@
 }
 
 <script>
-    var options = {valueNames: ['application-name']};
+    var options = { valueNames: [ 'application-name' ] };
     var serviceList = new List('whats-running-where-list', options);
 
     // re-search the list upon page load.

--- a/build.sbt
+++ b/build.sbt
@@ -62,8 +62,8 @@ val test = Seq(
   "com.vladsch.flexmark"   %  "flexmark-all"             % "0.35.10"            % Test,
   "com.typesafe.play"      %% "play-test"                % PlayVersion.current  % Test,
   "com.github.tomakehurst" %  "wiremock"                 % "1.58"               % Test,
-  "org.jsoup"              %  "jsoup"                    % "1.9.2"              % Test,
-  "org.mockito"            %% "mockito-scala"            % "1.10.2"             % Test,
+  "org.jsoup"              %  "jsoup"                    % "1.13.1"              % Test,
+  "org.mockito"            %% "mockito-scala"            % "1.10.6"             % Test,
   ws
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions += "-Ywarn-macros:after",
     playDefaultPort := 9017,
     libraryDependencies ++= compile ++ test,
+    scalacOptions ++= Seq("-Ywarn-macros:after"), //Remove lots of false warnings about unused implicits for json formats
     // ***************
     evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
     resolvers += Resolver.jcenterRepo,

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ lazy val microservice = Project(appName, file("."))
     scalacOptions += "-Ywarn-macros:after",
     playDefaultPort := 9017,
     libraryDependencies ++= compile ++ test,
-    scalacOptions ++= Seq("-Ywarn-macros:after"), //Remove lots of false warnings about unused implicits for json formats
     // ***************
     evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
     resolvers += Resolver.jcenterRepo,

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -65,5 +65,5 @@ GET        /shutter-events/list                         uk.gov.hmrc.cataloguefro
 GET        /whats-running-where                         uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereController.heritageReleases
 GET        /whats-running-where-ecs                     uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereController.ecsReleases
 
-GET        /deployments                                 uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.DeploymentHistoryController.history
+GET        /deployments/:env                            uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.DeploymentHistoryController.history(env: Environment)
 GET        /future-platform-migration                   uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.FuturePlatformMigrationController.futurePlatformMigration

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -35,8 +35,8 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModule"
 
 # Provides an implementation and configures all filters required by a Platform frontend microservice.
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
-play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.FrontendFilters"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
+play.http.filters = "uk.gov.hmrc.play.bootstrap.frontend.filters.FrontendFilters"
 
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.cataloguefrontend.CatalogueFrontendModule"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.7.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.8.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 

--- a/test/uk/gov/hmrc/cataloguefrontend/DeploymentHistoryControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DeploymentHistoryControllerSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend
+
+import org.mockito.MockitoSugar
+import org.mockito.ArgumentMatchers.any
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.cataloguefrontend.connector._
+import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
+import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.{DeploymentHistoryController, ReleasesConnector}
+import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
+import views.html.DeploymentHistoryPage
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DeploymentHistoryControllerSpec extends UnitSpec with MockitoSugar with GuiceOneAppPerSuite {
+  import ExecutionContext.Implicits.global
+
+  private trait Fixture {
+
+    lazy val mockedTeamsAndRepositoriesConnector = mock[TeamsAndRepositoriesConnector]
+    lazy val mockedReleasesConnector             = mock[ReleasesConnector]
+    lazy val page = new DeploymentHistoryPage()
+
+    lazy val controller = new DeploymentHistoryController(
+      mockedReleasesConnector,
+      mockedTeamsAndRepositoriesConnector,
+      page,
+      stubMessagesControllerComponents()
+    )
+  }
+
+  override def fakeApplication: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        "metrics.jvm" -> false
+      )
+      .build()
+
+  "history" should {
+    "return 400 when given a bad date" in new Fixture {
+      val response = controller.history()(FakeRequest(GET, "/deployments/production?from=baddate"))
+      status(response) shouldBe 400
+    }
+    "return 200 when given no filters" in new Fixture {
+      when(mockedReleasesConnector.deploymentHistory(any(), any(), any(), any(), any(), any())(any())).thenReturn(Future.successful(Seq.empty))
+      when(mockedTeamsAndRepositoriesConnector.allTeams(any())).thenReturn(Future.successful(Seq.empty))
+      val response = controller.history()(FakeRequest(GET, "/deployments/production"))
+      status(response) shouldBe 200
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/DeploymentsFilterSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DeploymentsFilterSpec.scala
@@ -16,54 +16,51 @@
 
 package uk.gov.hmrc.cataloguefrontend
 
-import java.time.format.DateTimeFormatter
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 
-import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.OptionValues
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
+import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.DeploymentHistoryController
 
-class DeploymentsFilterSpec extends AnyWordSpec with Matchers with OptionValues with TypeCheckedTripleEquals {
+class DeploymentsFilterSpec extends UnitSpec {
 
-  implicit def toDateTime(s: String): LocalDateTime =
-    LocalDate.parse(s, DateTimeFormatter.ofPattern("yyyy-MM-dd")).atStartOfDay()
+  import DateHelper._
+  import DeploymentHistoryController._
 
   val formData: Map[String, String] =
     Map("team" -> "teamA", "serviceName" -> "aService", "from" -> "2016-04-23", "to" -> "2016-05-25")
 
   "form" should {
-    "bind the form correctly" in {
-
-      DeploymentsFilter.form.bind(formData).value shouldBe Some(
-        DeploymentsFilter(Some("teamA"), Some("aService"), Some("2016-04-23"), Some("2016-05-25")))
-
-      DeploymentsFilter.form.bind(formData - "to").value shouldBe Some(
-        DeploymentsFilter(Some("teamA"), Some("aService"), Some("2016-04-23"), None))
-      DeploymentsFilter.form.bind(formData - "to" - "from").value shouldBe Some(
-        DeploymentsFilter(Some("teamA"), Some("aService"), None, None))
-      DeploymentsFilter.form.bind(formData - "team" - "serviceName" - "to" - "from").value shouldBe Some(
-        DeploymentsFilter(None, None, None, None))
-      DeploymentsFilter.form.bind(formData + ("team" -> "") + ("serviceName" -> "")).value shouldBe Some(
-        DeploymentsFilter(None, None, Some("2016-04-23"), Some("2016-05-25")))
-      DeploymentsFilter.form.bind(formData + ("team" -> " ") + ("serviceName" -> " ")).value shouldBe Some(
-        DeploymentsFilter(None, None, Some("2016-04-23"), Some("2016-05-25")))
-
+    "bind the form with defaults if no filters set" in {
+      DeploymentHistoryController.form.bind(Map.empty[String, String]).value shouldBe Some(
+        SearchForm(defaultFromTime(), defaultToTime(), None, None, None)
+      )
     }
-
-    "validate date is of correct format (dd-MM-yyyy)" in {
-
-      DeploymentsFilter.form.bind(formData + ("from" -> "23/04/2016")).error("from").value.message should ===(
-        "from.error.date")
-      DeploymentsFilter.form.bind(formData + ("from" -> "23/54/2016")).error("from").value.message should ===(
-        "from.error.date")
-      DeploymentsFilter.form.bind(formData + ("to" -> "23/04/2016")).error("to").value.message should ===(
-        "to.error.date")
-      DeploymentsFilter.form.bind(formData + ("to" -> "23/54/2016")).error("to").value.message should ===(
-        "to.error.date")
-
+    "bind the form with values set" in {
+      val formData = Map("from" -> "2020-06-10", "to" -> "2020-06-11", "team" -> "teamA", "search" -> "somesearch", "platform" -> "ecs")
+      DeploymentHistoryController.form.bind(formData).value shouldBe Some(
+        SearchForm(LocalDate.parse("2020-06-10").atStartOfDayEpochMillis, LocalDate.parse("2020-06-11").atEndOfDayEpochMillis,
+          Some("teamA"), Some("somesearch"), Some("ecs"))
+      )
     }
-
+    "error if the from date is before the to date" in {
+      val formData = Map("from" -> "2020-06-11", "to" -> "2020-06-10")
+      DeploymentHistoryController.form.bind(formData).errors.flatMap(_.messages) shouldBe List("To Date must be greater than or equal to From Date")
+    }
+    "error if the from date is the wrong format" in {
+      val formData = Map("from" -> "2020/06/11")
+      DeploymentHistoryController.form.bind(formData).errors.flatMap(_.messages) shouldBe List("error.date")
+    }
+    "allow setting the to date, defaulting from date" in {
+      val formData = Map("to" -> "2099-06-10")
+      DeploymentHistoryController.form.bind(formData).value shouldBe Some(
+        SearchForm(defaultFromTime(), LocalDate.parse("2099-06-10").atEndOfDayEpochMillis, None, None, None)
+      )
+    }
+    "allow setting the from date, defaulting to date" in {
+      val formData = Map("from" -> "2020-06-10")
+      DeploymentHistoryController.form.bind(formData).value shouldBe Some(
+        SearchForm(LocalDate.parse("2020-06-10").atStartOfDayEpochMillis, defaultToTime(), None, None, None)
+      )
+    }
   }
-
 }

--- a/test/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/DeploymentSpec.scala
@@ -20,18 +20,22 @@ import java.time.LocalDateTime
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import uk.gov.hmrc.cataloguefrontend.model.Environment.Production
+import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.Platform.Heritage
 
-class HeritageDeploymentSpec extends AnyFlatSpec with Matchers {
+class DeploymentSpec extends AnyFlatSpec with Matchers {
 
   "LastDeployer" should "select the most recent deployer" in {
 
     val now = LocalDateTime.now()
-    val h = HeritageDeployment(
+    val h = Deployment(
+      Heritage,
       ServiceName("foo"),
+      Production,
       VersionNumber("1.1.1"),
       Seq.empty,
       TimeSeen(LocalDateTime.now()),
-      None,
+      TimeSeen(LocalDateTime.now()),
       Seq(
         DeployerAudit("usera", TimeSeen(now.minusDays(3))),
         DeployerAudit("userb", TimeSeen(now.minusDays(1))),


### PR DESCRIPTION
1. Deployment page now pulls both ECS and heritage data out of `releases-api`. There is still a single page view for both, but ECS releases have a badge next to them
1. Page now shows data for all environments (not just Production) as before, on separate tabs
1. Improved the form by adding type-a-head search, sorting, and auto reloading
1. Now shows all deployments for a given version, not just the first time a particular version was seen, as was the case before (i.e. previously multiple deployments of the same version would only show once, for the original deployment)
1. Also added sorting to the shuttering overview and repository pages