### PR TITLE
Fix links for trailing slash

### DIFF
--- a/app/views/partials/code_and_builds.scala.html
+++ b/app/views/partials/code_and_builds.scala.html
@@ -14,8 +14,10 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.cataloguefrontend.connector.RepositoryDetails
-@import uk.gov.hmrc.cataloguefrontend.connector.RepoType
+@import uk.gov.hmrc.cataloguefrontend.connector.{RepositoryDetails, RepoType}
+@import uk.gov.hmrc.cataloguefrontend.model.Environment
+@import uk.gov.hmrc.cataloguefrontend.routes.{CatalogueController, DependenciesController}
+@import uk.gov.hmrc.cataloguefrontend.shuttering.routes.ShutterOverviewController
 @import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.EnvironmentRoute
 
 @(repo: RepositoryDetails)
@@ -26,13 +28,13 @@
         <div class="board__body">
             <ul class="list list--minimal list-two-columns">
                 <li class="list-item"><a id="link-to-@{repo.githubUrl.id}" href="@{repo.githubUrl.url}" target="_blank">@{repo.githubUrl.displayName}<span class="glyphicon glyphicon-new-window"/></a></li>
-                <li class="list-item"><a id="link-to-@{repo.name}-config" href="@{repo.name}/config" target="_blank">Config Explorer<span class="glyphicon glyphicon-new-window"/></a></li>
+                <li class="list-item"><a id="link-to-@{repo.name}-config" href="@{CatalogueController.serviceConfig(repo.name)}" target="_blank">Config Explorer<span class="glyphicon glyphicon-new-window"/></a></li>
             @for(ciLink <- repo.jenkinsURL) {
                 <li class="list-item"><a id="link-to-@{ciLink.id}" href="@{ciLink.url}" target="_blank">@{ciLink.displayName}<span class="glyphicon glyphicon-new-window"/></a></li>
             }
             @if(repo.repoType == RepoType.Service) {
-                <li class="list-item"><a id="link-to-dependency-explorer" href="/dependencies/@{repo.name}" target="_blank">Service Dependencies<span class="glyphicon glyphicon-new-window"/></a></li>
-                <li class="list-item"><a id="link-to-frontend-route-warnings" href="/frontend-route-warnings/production/@{repo.name}" target="_blank">Frontend Route Warnings<span class="glyphicon glyphicon-new-window"/></a></li>
+                <li class="list-item"><a id="link-to-dependency-explorer" href="@{DependenciesController.service(repo.name)}" target="_blank">Service Dependencies<span class="glyphicon glyphicon-new-window"/></a></li>
+                <li class="list-item"><a id="link-to-frontend-route-warnings" href="@{ShutterOverviewController.frontendRouteWarnings(Environment.Production, repo.name)}" target="_blank">Frontend Route Warnings<span class="glyphicon glyphicon-new-window"/></a></li>
             }
             </ul>
         </div>

--- a/test/view/partials/CodeAndBuildsSpec.scala
+++ b/test/view/partials/CodeAndBuildsSpec.scala
@@ -38,7 +38,7 @@ class CodeAndBuildsSpec extends AnyWordSpec with Matchers with ScalaCheckDrivenP
 
     "display configuration explorer" in {
       val result = views.html.partials.code_and_builds(repo).body
-      result should include ("href=\"reponame/config\"")
+      result should include ("href=\"/service/reponame/config\"")
       result should include ("Config Explorer")
     }
 


### PR DESCRIPTION
As well as not being checked by the compiler, the links could break if the page was loaded with an additional `/`
e.g. `/service/myservice/` leads to `/service/myservice/myservice/conf` rather than `/service/myservice/conf`