### PR TITLE
adds basic display page for repo health indicators + connector + testing

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/DependenciesController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/DependenciesController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.cataloguefrontend
 
-import javax.inject.{Inject, Singleton}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.cataloguefrontend.connector.model.Version
 import uk.gov.hmrc.cataloguefrontend.service.DependenciesService
@@ -24,6 +23,7 @@ import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.DependenciesPage
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
@@ -87,13 +87,13 @@ object Rating {
   }
 }
 
-case class RepositoryRating(repositoryName: String, repositoryScore: Int, ratings: Option[Seq[Rating]])
+case class RepositoryRating(repositoryName: String, repositoryScore: Int, ratings: Seq[Rating])
 
 object RepositoryRating {
   val reads: Reads[RepositoryRating] = {
     implicit val sR: Reads[Rating] = Rating.reads
     ((__ \ "repositoryName").read[String]
       ~ (__ \ "repositoryScore").read[Int]
-      ~ (__ \ "ratings").readNullable[Seq[Rating]])(RepositoryRating.apply _)
+      ~ (__ \ "ratings").read[Seq[Rating]])(RepositoryRating.apply _)
   }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
@@ -24,14 +24,11 @@ import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
-
-
 @Singleton
 class HealthIndicatorsConnector @Inject()(
-                                              http          : HttpClient,
-                                              servicesConfig: ServicesConfig
-                                            )(implicit val ec: ExecutionContext
-                                            ) {
+  http: HttpClient,
+  servicesConfig: ServicesConfig
+)(implicit val ec: ExecutionContext) {
   import HttpReads.Implicits._
   private val logger = Logger(getClass)
 
@@ -39,7 +36,7 @@ class HealthIndicatorsConnector @Inject()(
 
   def getHealthIndicators(repoName: String)(implicit hc: HeaderCarrier): Future[Option[RepositoryRating]] = {
     implicit val rrR: Reads[RepositoryRating] = RepositoryRating.reads
-    val url = s"$healthIndicatorsBaseUrl/repositories/$repoName"
+    val url                                   = s"$healthIndicatorsBaseUrl/repositories/$repoName"
     http
       .GET[Option[RepositoryRating]](url)
       .recover {
@@ -61,7 +58,7 @@ object Score {
 
 case class Rating(ratingType: String, ratingScore: Int, breakdown: Seq[Score])
 
-object Rating{
+object Rating {
   val reads: Reads[Rating] = {
     implicit val sR: Reads[Score] = Score.reads
     ((__ \ "ratingType").read[String]
@@ -72,7 +69,7 @@ object Rating{
 
 case class RepositoryRating(repositoryName: String, repositoryScore: Int, ratings: Option[Seq[Rating]])
 
-object RepositoryRating{
+object RepositoryRating {
   val reads: Reads[RepositoryRating] = {
     implicit val sR: Reads[Rating] = Rating.reads
     ((__ \ "repositoryName").read[String]

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
@@ -36,7 +36,7 @@ class HealthIndicatorsConnector @Inject()(
 
   def getHealthIndicators(repoName: String)(implicit hc: HeaderCarrier): Future[Option[RepositoryRating]] = {
     implicit val rrR: Reads[RepositoryRating] = RepositoryRating.reads
-    val url                                   = s"$healthIndicatorsBaseUrl/repositories/$repoName"
+    val url                                   = s"$healthIndicatorsBaseUrl/health-indicators/repositories/$repoName"
     http
       .GET[Option[RepositoryRating]](url)
       .recover {

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.healthindicators
+
+import play.api.Logger
+import play.api.libs.functional.syntax.toFunctionalBuilderOps
+import play.api.libs.json.{Reads, __}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+
+@Singleton
+class HealthIndicatorsConnector @Inject()(
+                                              http          : HttpClient,
+                                              servicesConfig: ServicesConfig
+                                            )(implicit val ec: ExecutionContext
+                                            ) {
+  import HttpReads.Implicits._
+  private val logger = Logger(getClass)
+
+  private val healthIndicatorsBaseUrl: String = servicesConfig.baseUrl("health-indicators")
+
+  def getHealthIndicators(repoName: String)(implicit hc: HeaderCarrier): Future[Option[RepositoryRating]] = {
+    implicit val rrR: Reads[RepositoryRating] = RepositoryRating.reads
+    val url = s"$healthIndicatorsBaseUrl/repositories/$repoName"
+    http
+      .GET[Option[RepositoryRating]](url)
+      .recover {
+        case ex =>
+          logger.error(s"An error occurred when connecting to $url: ${ex.getMessage}", ex)
+          None
+      }
+  }
+}
+
+case class Score(points: Int, description: String, href: Option[String])
+
+object Score {
+  val reads: Reads[Score] =
+    ((__ \ "points").read[Int]
+      ~ (__ \ "description").read[String]
+      ~ (__ \ "href").readNullable[String])(Score.apply _)
+}
+
+case class Rating(ratingType: String, ratingScore: Int, breakdown: Seq[Score])
+
+object Rating{
+  val reads: Reads[Rating] = {
+    implicit val sR: Reads[Score] = Score.reads
+    ((__ \ "ratingType").read[String]
+      ~ (__ \ "ratingScore").read[Int]
+      ~ (__ \ "breakdown").read[Seq[Score]])(Rating.apply _)
+  }
+}
+
+case class RepositoryRating(repositoryName: String, repositoryScore: Int, ratings: Option[Seq[Rating]])
+
+object RepositoryRating{
+  val reads: Reads[RepositoryRating] = {
+    implicit val sR: Reads[Rating] = Rating.reads
+    ((__ \ "repositoryName").read[String]
+      ~ (__ \ "repositoryScore").read[Int]
+      ~ (__ \ "ratings").readNullable[Seq[Rating]])(RepositoryRating.apply _)
+  }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnector.scala
@@ -39,11 +39,6 @@ class HealthIndicatorsConnector @Inject()(
     val url                                   = s"$healthIndicatorsBaseUrl/health-indicators/repositories/$repoName"
     http
       .GET[Option[RepositoryRating]](url)
-      .recover {
-        case ex =>
-          logger.error(s"An error occurred when connecting to $url: ${ex.getMessage}", ex)
-          None
-      }
   }
 }
 

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
@@ -37,3 +37,13 @@ class HealthIndicatorsController @Inject()(
       }
     }
 }
+
+object HealthIndicatorsController {
+  def getScoreColour(score: Int): String ={
+    score match {
+      case x if x > 0 => "repo-score-green"
+      case x if x > -100 => "repo-score-amber"
+      case _ => "repo-score-red"
+    }
+  }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.{HealthIndicatorsPage, error_404_template}
 
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 class HealthIndicatorsController @Inject()(
   healthIndicatorsConnector: HealthIndicatorsConnector,
@@ -29,9 +29,9 @@ class HealthIndicatorsController @Inject()(
 )(implicit val ec: ExecutionContext)
     extends FrontendController(mcc) {
 
-  def indicatorsForRepo(repo: String): Action[AnyContent] =
+  def indicatorsForRepo(name: String): Action[AnyContent] =
     Action.async { implicit request =>
-      healthIndicatorsConnector.getHealthIndicators(repo).map {
+      healthIndicatorsConnector.getHealthIndicators(name).map {
         case Some(repositoryRating: RepositoryRating) => Ok(HealthIndicatorsPage(repositoryRating))
         case None                                     => NotFound(error_404_template())
       }

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
@@ -31,12 +31,9 @@ class HealthIndicatorsController @Inject()(
 
   def indicatorsForRepo(repo: String): Action[AnyContent] =
     Action.async { implicit request =>
-      for {
-        repositoryRating <- healthIndicatorsConnector.getHealthIndicators(repo)
-      } yield
-        repositoryRating match {
-          case Some(_) => Ok(HealthIndicatorsPage(repositoryRating.get))
-          case None    => NotFound(error_404_template())
-        }
+      healthIndicatorsConnector.getHealthIndicators(repo).map {
+        case Some(repositoryRating: RepositoryRating) => Ok(HealthIndicatorsPage(repositoryRating))
+        case None                                     => NotFound(error_404_template())
+      }
     }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
@@ -25,19 +25,18 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class HealthIndicatorsController @Inject()(
   healthIndicatorsConnector: HealthIndicatorsConnector,
-                                            mcc    : MessagesControllerComponents
-                                          )(implicit val ec: ExecutionContext)
-  extends FrontendController(mcc){
+  mcc: MessagesControllerComponents
+)(implicit val ec: ExecutionContext)
+    extends FrontendController(mcc) {
 
-     def indicatorsForRepo(repo: String): Action[AnyContent] = {
-
-       Action.async { implicit request =>
-         for {
-           repositoryRating <- healthIndicatorsConnector.getHealthIndicators(repo)
-         } yield repositoryRating match {
-           case Some(_) => Ok(HealthIndicatorsPage(repositoryRating.get))
-           case None => NotFound(error_404_template())
-         }
-       }
-     }
+  def indicatorsForRepo(repo: String): Action[AnyContent] =
+    Action.async { implicit request =>
+      for {
+        repositoryRating <- healthIndicatorsConnector.getHealthIndicators(repo)
+      } yield
+        repositoryRating match {
+          case Some(_) => Ok(HealthIndicatorsPage(repositoryRating.get))
+          case None    => NotFound(error_404_template())
+        }
+    }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsController.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.healthindicators
+
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.{HealthIndicatorsPage, error_404_template}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class HealthIndicatorsController @Inject()(
+  healthIndicatorsConnector: HealthIndicatorsConnector,
+                                            mcc    : MessagesControllerComponents
+                                          )(implicit val ec: ExecutionContext)
+  extends FrontendController(mcc){
+
+     def indicatorsForRepo(repo: String): Action[AnyContent] = {
+
+       Action.async { implicit request =>
+         for {
+           repositoryRating <- healthIndicatorsConnector.getHealthIndicators(repo)
+         } yield repositoryRating match {
+           case Some(_) => Ok(HealthIndicatorsPage(repositoryRating.get))
+           case None => NotFound(error_404_template())
+         }
+       }
+     }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/WhatsRunningWhereController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/WhatsRunningWhereController.scala
@@ -17,8 +17,6 @@
 package uk.gov.hmrc.cataloguefrontend.whatsrunningwhere
 
 import cats.implicits._
-
-import javax.inject.{Inject, Singleton}
 import play.api.data.Form
 import play.api.data.Forms.{mapping, optional, text}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -26,6 +24,7 @@ import uk.gov.hmrc.cataloguefrontend.model.Environment
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.whatsrunningwhere.WhatsRunningWherePage
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/views/HealthIndicatorsPage.scala.html
+++ b/app/views/HealthIndicatorsPage.scala.html
@@ -40,8 +40,7 @@
             <th>Reason</th>
             <th>Score Contribution</th>
         </thead>
-        @indicator.ratings.map { r =>
-            @r.zipWithIndex.map{ case (rating, i ) =>
+        @indicator.ratings.zipWithIndex.map{ case (rating, i ) =>
               <section id="section_@{i}_@{rating.ratingType}">
                 <tr role="row" id="section_@{i}_row_1">
                     <td id="section_@{i}_row_0_col_0">@rating.ratingType</td>
@@ -63,7 +62,7 @@
                   </tr>
               }
             </section>
-        }}
+        }
     </table>
   </div>
 }

--- a/app/views/HealthIndicatorsPage.scala.html
+++ b/app/views/HealthIndicatorsPage.scala.html
@@ -16,12 +16,16 @@
 
 @import uk.gov.hmrc.cataloguefrontend.healthindicators.RepositoryRating
 
+@import uk.gov.hmrc.cataloguefrontend.healthindicators.HealthIndicatorsController
 @(indicator: RepositoryRating
 )(implicit messages: Messages, request: Request[_])
 @standard_layout("Service Health Indicators", "health-indicators"){
 
   <header>
-      <p id="repo-score-number">@indicator.repositoryScore</p>
+      <p id="repo-score-number"
+      class=@HealthIndicatorsController.getScoreColour(indicator.repositoryScore)>
+      @indicator.repositoryScore
+      </p>
     <h1>Service Health Indicators:  @indicator.repositoryName
         <a id="health-indicators-help" href="https://github.com/hmrc/health-indicators" title="What is this?">?</a>
     </h1>
@@ -63,13 +67,3 @@
     </table>
   </div>
 }
-
-<script>
-    getScoreColour = (score) => {
-        if(score > 0){return "repo-score-green"}
-        else if(score>-200){return "repo-score-amber"}
-        else{return "repo-score-red"}
-    }
-
-    document.getElementById("repo-score-number").classList.add(getScoreColour(@indicator.repositoryScore))
-</script>

--- a/app/views/HealthIndicatorsPage.scala.html
+++ b/app/views/HealthIndicatorsPage.scala.html
@@ -1,0 +1,75 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.healthindicators.RepositoryRating
+
+@(indicator: RepositoryRating
+)(implicit messages: Messages, request: Request[_])
+@standard_layout("Service Health Indicators", "health-indicators"){
+
+  <header>
+      <p id="repo-score-number">@indicator.repositoryScore</p>
+    <h1>Service Health Indicators:  @indicator.repositoryName
+        <a id="health-indicators-help" href="https://github.com/hmrc/health-indicators">?</a>
+    </h1>
+  </header>
+  <div id="health-indicators-display">
+    <h2>Score Breakdown:</h2>
+      <br />
+    <table class="table table-striped" id="service-list">
+        <thead>
+            <th>Indicator</th>
+            <th>Indicator Score</th>
+            <th>Reason</th>
+            <th>Points</th>
+        </thead>
+        @indicator.ratings.map { r =>
+            @r.zipWithIndex.map{ case (rating, i ) =>
+              <section id="section_@{i}_@{rating.ratingType}">
+                <tr role="row" id="section_@{i}_row_1">
+                    <td id="section_@{i}_row_0_col_0">@rating.ratingType</td>
+                    <td id="section_@{i}_row_0_col_1">@rating.ratingScore</td>
+                    @if(rating.breakdown.isEmpty){
+                        <td id="section_@{i}_row_0_col_2"></td>
+                        <td id="section_@{i}_row_0_col_3"></td>
+                    }else{
+                        <td id="section_@{i}_row_0_col_2">@rating.breakdown.head.description</td>
+                        <td id="section_@{i}_row_0_col_3">@rating.breakdown.head.points</td>
+                    }
+                </tr>
+              @rating.breakdown.drop(1).zipWithIndex.map { case (breakdown, j) =>
+                  <tr>
+                      <td id="section_@{i}row@{j+1}_col_0"></td>
+                      <td id="section_@{i}row@{j+1}_col_1"></td>
+                      <td id="section_@{i}row@{j+1}_col_2">@breakdown.description</td>
+                      <td id="section_@{i}row@{j+1}_col_3">@breakdown.points</td>
+                  </tr>
+              }
+            </section>
+        }}
+    </table>
+  </div>
+}
+
+<script>
+    getScoreColour = (score) => {
+        if(score > 0){return "repo-score-green"}
+        else if(score>-200){return "repo-score-amber"}
+        else{return "repo-score-red"}
+    }
+
+    document.getElementById("repo-score-number").classList.add(getScoreColour(@indicator.repositoryScore))
+</script>

--- a/app/views/HealthIndicatorsPage.scala.html
+++ b/app/views/HealthIndicatorsPage.scala.html
@@ -32,9 +32,9 @@
     <table class="table table-striped" id="service-list">
         <thead>
             <th>Indicator</th>
-            <th>Indicator Score</th>
+            <th>Indicator Total Score</th>
             <th>Reason</th>
-            <th>Points</th>
+            <th>Score Contribution</th>
         </thead>
         @indicator.ratings.map { r =>
             @r.zipWithIndex.map{ case (rating, i ) =>

--- a/app/views/HealthIndicatorsPage.scala.html
+++ b/app/views/HealthIndicatorsPage.scala.html
@@ -23,7 +23,7 @@
   <header>
       <p id="repo-score-number">@indicator.repositoryScore</p>
     <h1>Service Health Indicators:  @indicator.repositoryName
-        <a id="health-indicators-help" href="https://github.com/hmrc/health-indicators">?</a>
+        <a id="health-indicators-help" href="https://github.com/hmrc/health-indicators" title="What is this?">?</a>
     </h1>
   </header>
   <div id="health-indicators-display">

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -15,6 +15,7 @@ GET        /services                                    uk.gov.hmrc.cataloguefro
 GET        /service/:name                               uk.gov.hmrc.cataloguefrontend.CatalogueController.service(name)
 GET        /service/:name/config                        uk.gov.hmrc.cataloguefrontend.CatalogueController.serviceConfig(name)
 GET        /service/:name/config/raw                    uk.gov.hmrc.cataloguefrontend.CatalogueController.serviceConfigRaw(name)
+GET        /service/:name/health                   uk.gov.hmrc.cataloguefrontend.healthindicators.HealthIndicatorsController.indicatorsForRepo(name: String)
 GET        /libraries                                   uk.gov.hmrc.cataloguefrontend.CatalogueController.allLibraries
 GET        /library/:name                               uk.gov.hmrc.cataloguefrontend.CatalogueController.library(name)
 GET        /prototypes                                  uk.gov.hmrc.cataloguefrontend.CatalogueController.allPrototypes
@@ -69,4 +70,3 @@ GET        /deployments/:env                            uk.gov.hmrc.cataloguefro
 
 
 
-GET         /test/health-indicators/:repo                    uk.gov.hmrc.cataloguefrontend.healthindicators.HealthIndicatorsController.indicatorsForRepo(repo: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -66,3 +66,7 @@ GET        /whats-running-where-heritage                uk.gov.hmrc.cataloguefro
 GET        /whats-running-where                         uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereController.ecsReleases(showDiff: Boolean ?= false)
 
 GET        /deployments/:env                            uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.DeploymentHistoryController.history(env: Environment)
+
+
+
+GET         /test/health-indicators/:repo                    uk.gov.hmrc.cataloguefrontend.healthindicators.HealthIndicatorsController.indicatorsForRepo(repo: String)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -15,7 +15,7 @@ GET        /services                                    uk.gov.hmrc.cataloguefro
 GET        /service/:name                               uk.gov.hmrc.cataloguefrontend.CatalogueController.service(name)
 GET        /service/:name/config                        uk.gov.hmrc.cataloguefrontend.CatalogueController.serviceConfig(name)
 GET        /service/:name/config/raw                    uk.gov.hmrc.cataloguefrontend.CatalogueController.serviceConfigRaw(name)
-GET        /service/:name/health                   uk.gov.hmrc.cataloguefrontend.healthindicators.HealthIndicatorsController.indicatorsForRepo(name: String)
+GET        /service/:name/health-indicators             uk.gov.hmrc.cataloguefrontend.healthindicators.HealthIndicatorsController.indicatorsForRepo(name: String)
 GET        /libraries                                   uk.gov.hmrc.cataloguefrontend.CatalogueController.allLibraries
 GET        /library/:name                               uk.gov.hmrc.cataloguefrontend.CatalogueController.library(name)
 GET        /prototypes                                  uk.gov.hmrc.cataloguefrontend.CatalogueController.allPrototypes

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -187,6 +187,11 @@ microservice {
       host = "localhost"
       port = 8008
     }
+
+    health-indicators {
+      host = "localhost"
+      port = 9018
+    }
   }
 }
 

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -12390,3 +12390,39 @@ table.shutter-events {
 .wrw-environment-head{
   width: 12%;
 }
+
+#repo-score-number{
+  border-radius: 20px;
+  border-style: solid;
+  border-width: 10px;
+  border-color: white;
+  font-size: 2.4em;
+  color: white;
+  float: right;
+  padding: 3px 7px 0 7px;
+}
+
+.repo-score-amber{
+  background-color: rgba(226, 156, 44, 1);
+}
+
+.repo-score-green{
+  background-color: green;
+}
+
+.repo-score-red{
+  background-color: red;
+}
+
+#health-indicators-help{
+  display: inline;
+  color: white;
+  background-color: grey;
+  border-radius: 100px;
+  padding: 2px 9px;
+  font-size: 0.5em;
+  font-weight: normal;
+  position: relative;
+  bottom: 6px;
+  left: 10px;
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/DependencyReportControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DependencyReportControllerSpec.scala
@@ -16,14 +16,9 @@
 
 package uk.gov.hmrc.cataloguefrontend
 
-import java.time.{Instant, LocalDateTime}
-
 import akka.stream.Materializer
 import org.mockito.ArgumentMatchers.{eq => eqTo, _}
 import org.mockito.MockitoSugar
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector.DigitalService.DigitalServiceRepository
@@ -33,9 +28,10 @@ import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependencies, Dependency, 
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
+import java.time.{Instant, LocalDateTime}
 import scala.concurrent.{ExecutionContext, Future}
 
-class DependencyReportControllerSpec extends UnitSpec with MockitoSugar with GuiceOneAppPerSuite {
+class DependencyReportControllerSpec extends UnitSpec with MockitoSugar with FakeApplicationBuilder {
   import ExecutionContext.Implicits.global
 
   private val now: LocalDateTime = LocalDateTime.now()
@@ -49,13 +45,6 @@ class DependencyReportControllerSpec extends UnitSpec with MockitoSugar with Gui
     mockedDependenciesConnector,
     stubMessagesControllerComponents()
   )
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "metrics.jvm" -> false
-      )
-      .build()
 
   "dependencyReport" should {
 

--- a/test/uk/gov/hmrc/cataloguefrontend/DeploymentHistoryControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DeploymentHistoryControllerSpec.scala
@@ -16,13 +16,8 @@
 
 package uk.gov.hmrc.cataloguefrontend
 
-import java.time.{Instant, LocalDate}
-
 import org.mockito.ArgumentMatchers.any
 import org.mockito.MockitoSugar
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector._
@@ -33,9 +28,10 @@ import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere._
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import views.html.DeploymentHistoryPage
 
+import java.time.{Instant, LocalDate}
 import scala.concurrent.{ExecutionContext, Future}
 
-class DeploymentHistoryControllerSpec extends UnitSpec with MockitoSugar with GuiceOneAppPerSuite {
+class DeploymentHistoryControllerSpec extends UnitSpec with MockitoSugar with FakeApplicationBuilder {
   import ExecutionContext.Implicits.global
 
   private trait Fixture {
@@ -51,13 +47,6 @@ class DeploymentHistoryControllerSpec extends UnitSpec with MockitoSugar with Gu
       stubMessagesControllerComponents()
     )
   }
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "metrics.jvm" -> false
-      )
-      .build()
 
   "history" should {
     "return 400 when given a bad date" in new Fixture {

--- a/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
@@ -21,17 +21,15 @@ import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.mockito.ArgumentMatchers._
 import org.mockito.MockitoSugar
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.Configuration
 import play.api.libs.ws._
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{GET => _, _}
-import play.api.{Application, Configuration}
 import uk.gov.hmrc.cataloguefrontend.actions.{ActionsSupport, UmpVerifiedRequest}
 import uk.gov.hmrc.cataloguefrontend.connector.UserManagementAuthConnector.User
 import uk.gov.hmrc.cataloguefrontend.connector.UserManagementConnector.{TeamMember, UMPError}
-import uk.gov.hmrc.cataloguefrontend.connector.model.{TeamName, Username}
 import uk.gov.hmrc.cataloguefrontend.connector._
+import uk.gov.hmrc.cataloguefrontend.connector.model.{TeamName, Username}
 import uk.gov.hmrc.cataloguefrontend.events.{EventService, ReadModelService}
 import uk.gov.hmrc.cataloguefrontend.service._
 import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterService
@@ -45,23 +43,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.io.Source
 
-class DigitalServicePageSpec extends UnitSpec with GuiceOneServerPerSuite with WireMockEndpoints with MockitoSugar with ActionsSupport {
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.teams-and-repositories.host"  -> host,
-        "microservice.services.teams-and-repositories.port"  -> endpointPort,
-        "microservice.services.indicators.port"              -> endpointPort,
-        "microservice.services.indicators.host"              -> host,
-        "microservice.services.user-management.url"          -> endpointMockUrl,
-        "usermanagement.portal.url"                          -> "http://usermanagement/link",
-        "microservice.services.user-management.frontPageUrl" -> "http://some.ump.fontpage.com",
-        "play.ws.ssl.loose.acceptAnyCertificate"             -> true,
-        "play.http.requestHandler"                           -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                        -> false
-      )
-      .build()
+class DigitalServicePageSpec extends UnitSpec with FakeApplicationBuilder with MockitoSugar with ActionsSupport {
 
   private[this] lazy val WS                     = app.injector.instanceOf[WSClient]
   private[this] lazy val viewMessages           = app.injector.instanceOf[ViewMessages]

--- a/test/uk/gov/hmrc/cataloguefrontend/DigitalServicesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DigitalServicesSpec.scala
@@ -20,25 +20,10 @@ import com.github.tomakehurst.wiremock.http.RequestMethod.GET
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.BeforeAndAfter
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
-class DigitalServicesSpec extends UnitSpec with BeforeAndAfter with GuiceOneServerPerSuite with WireMockEndpoints {
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        Map(
-          "microservice.services.teams-and-repositories.port" -> endpointPort,
-          "microservice.services.teams-and-repositories.host" -> host,
-          "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-          "metrics.jvm"                                       -> false
-        )
-      )
-      .build()
+class DigitalServicesSpec extends UnitSpec with BeforeAndAfter with FakeApplicationBuilder {
 
   private[this] lazy val WS = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/FakeApplicationBuilder.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/FakeApplicationBuilder.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend
+
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+
+trait FakeApplicationBuilder
+  extends AnyWordSpecLike
+  with GuiceOneServerPerSuite
+  with WireMockEndpoints{
+
+  override def fakeApplication: Application =
+    new GuiceApplicationBuilder()
+      .disable(classOf[com.kenshoo.play.metrics.PlayModule])
+      .configure(
+        Map(
+          "microservice.services.health-indicators.port" -> endpointPort,
+          "microservice.services.health-indicators.host" -> host,
+          "microservice.services.teams-and-repositories.port" -> endpointPort,
+          "microservice.services.teams-and-repositories.host" -> host,
+          "microservice.services.indicators.port"             -> endpointPort,
+          "microservice.services.indicators.host"             -> host,
+          "microservice.services.service-dependencies.host"   -> host,
+          "microservice.services.service-dependencies.port"   -> endpointPort,
+          "microservice.services.leak-detection.port"         -> endpointPort,
+          "microservice.services.leak-detection.host"         -> host,
+          "microservice.services.service-configs.port"        -> endpointPort,
+          "microservice.services.service-configs.host"        -> host,
+          "microservice.services.shutter-api.port"            -> endpointPort,
+          "microservice.services.shutter-api.host"            -> host,
+          "microservice.services.releases-api.port"           -> endpointPort,
+          "microservice.services.releases-api.host"           -> host,
+          "microservice.services.user-management.url"          -> endpointMockUrl,
+          "github.open.api.rawurl"                            -> endpointMockUrl,
+          "github.open.api.token"                             -> "",
+          "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
+          "usermanagement.portal.url"                          -> "http://usermanagement/link",
+          "microservice.services.user-management.frontPageUrl" -> "http://some.ump.fontpage.com",
+          "microservice.services.user-management.myTeamsUrl"   -> "http://some.ump.com/myTeams",
+          "play.ws.ssl.loose.acceptAnyCertificate"             -> true,
+          "play.http.requestHandler"                           -> "play.api.http.DefaultHttpRequestHandler",
+          "team.hideArchivedRepositories"                      -> true,
+          "metrics.jvm"                                        -> false
+        ))
+      .build()
+
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/FrontendRouteWarningsPageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/FrontendRouteWarningsPageSpec.scala
@@ -17,20 +17,10 @@
 package uk.gov.hmrc.cataloguefrontend
 
 import com.github.tomakehurst.wiremock.http.RequestMethod._
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
-class FrontendRouteWarningsPageSpec extends UnitSpec with GuiceOneServerPerSuite with WireMockEndpoints {
-
-  override def fakeApplication: Application = new GuiceApplicationBuilder()
-    .configure(
-      "microservice.services.shutter-api.port"          -> endpointPort,
-      "microservice.services.shutter-api.host"          -> host
-    )
-    .build()
+class FrontendRouteWarningsPageSpec extends UnitSpec with FakeApplicationBuilder {
 
   private[this] lazy val ws = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/LibraryPageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/LibraryPageSpec.scala
@@ -19,30 +19,11 @@ package uk.gov.hmrc.cataloguefrontend
 import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.jsoup.Jsoup
 import org.scalatest.BeforeAndAfter
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.JsonData._
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
-class LibraryPageSpec extends UnitSpec with BeforeAndAfter with GuiceOneServerPerSuite with WireMockEndpoints {
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.teams-and-repositories.host" -> host,
-        "microservice.services.teams-and-repositories.port" -> endpointPort,
-        "microservice.services.indicators.port"             -> endpointPort,
-        "microservice.services.indicators.host"             -> host,
-        "microservice.services.service-dependencies.host"   -> host,
-        "microservice.services.service-dependencies.port"   -> endpointPort,
-        "microservice.services.leak-detection.port"         -> endpointPort,
-        "microservice.services.leak-detection.host"         -> host,
-        "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                       -> false
-      )
-      .build()
+class LibraryPageSpec extends UnitSpec with BeforeAndAfter with FakeApplicationBuilder {
 
   private[this] lazy val WS = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/PrototypePageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/PrototypePageSpec.scala
@@ -17,26 +17,14 @@
 package uk.gov.hmrc.cataloguefrontend
 
 import com.github.tomakehurst.wiremock.http.RequestMethod._
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.DateHelper._
 import uk.gov.hmrc.cataloguefrontend.JsonData._
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
-class PrototypePageSpec extends UnitSpec with GuiceOneServerPerSuite with WireMockEndpoints {
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.teams-and-repositories.port" -> endpointPort,
-        "microservice.services.teams-and-repositories.host" -> host,
-        "microservice.services.leak-detection.port"         -> endpointPort,
-        "microservice.services.leak-detection.host"         -> host,
-        "metrics.jvm"                                       -> false
-      )
-      .build()
+class PrototypePageSpec
+  extends UnitSpec
+  with FakeApplicationBuilder {
 
   private[this] lazy val WS = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/RepositoriesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/RepositoriesSpec.scala
@@ -20,26 +20,11 @@ import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.BeforeAndAfter
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.DateHelper._
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
-class RepositoriesSpec extends UnitSpec with BeforeAndAfter with GuiceOneServerPerSuite with WireMockEndpoints {
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        Map(
-          "microservice.services.teams-and-repositories.port" -> endpointPort,
-          "microservice.services.teams-and-repositories.host" -> host,
-          "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-          "metrics.jvm"                                       -> false
-        )
-      )
-      .build()
+class RepositoriesSpec extends UnitSpec with BeforeAndAfter with FakeApplicationBuilder {
 
   private[this] lazy val WS = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/RepositoryPageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/RepositoryPageSpec.scala
@@ -20,9 +20,6 @@ import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterEach}
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.connector.RepoType
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
@@ -30,8 +27,7 @@ import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 class RepositoryPageSpec
     extends UnitSpec
     with BeforeAndAfter
-    with GuiceOneServerPerSuite
-    with WireMockEndpoints
+    with FakeApplicationBuilder
     with BeforeAndAfterEach {
 
   case class RepositoryDetails(repositoryName: String, repositoryType: RepoType.RepoType)
@@ -41,20 +37,6 @@ class RepositoryPageSpec
     RepositoryDetails("Library", RepoType.Library),
     RepositoryDetails("Other", RepoType.Other)
   )
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.teams-and-repositories.host" -> host,
-        "microservice.services.teams-and-repositories.port" -> endpointPort,
-        "microservice.services.service-dependencies.host"   -> host,
-        "microservice.services.service-dependencies.port"   -> endpointPort,
-        "microservice.services.leak-detection.port"         -> endpointPort,
-        "microservice.services.leak-detection.host"         -> host,
-        "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                       -> false
-      )
-      .build()
 
   private[this] lazy val WS = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/ServicePageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/ServicePageSpec.scala
@@ -18,9 +18,6 @@ package uk.gov.hmrc.cataloguefrontend
 
 import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.jsoup.Jsoup
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.DateHelper._
 import uk.gov.hmrc.cataloguefrontend.JsonData._
@@ -29,29 +26,7 @@ import uk.gov.hmrc.cataloguefrontend.shuttering.{ShutterStatusValue, ShutterType
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.JsonCodecs
 
-class ServicePageSpec extends UnitSpec with GuiceOneServerPerSuite with WireMockEndpoints {
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.teams-and-repositories.port" -> endpointPort,
-        "microservice.services.teams-and-repositories.host" -> host,
-        "microservice.services.indicators.port"             -> endpointPort,
-        "microservice.services.indicators.host"             -> host,
-        "microservice.services.service-dependencies.host"   -> host,
-        "microservice.services.service-dependencies.port"   -> endpointPort,
-        "microservice.services.leak-detection.port"         -> endpointPort,
-        "microservice.services.leak-detection.host"         -> host,
-        "microservice.services.service-configs.port"        -> endpointPort,
-        "microservice.services.service-configs.host"        -> host,
-        "microservice.services.shutter-api.port"            -> endpointPort,
-        "microservice.services.shutter-api.host"            -> host,
-        "microservice.services.releases-api.port"           -> endpointPort,
-        "microservice.services.releases-api.host"           -> host,
-        "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                       -> false
-      )
-      .build()
+class ServicePageSpec extends UnitSpec with FakeApplicationBuilder {
 
   private[this] lazy val ws = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/TeamServicesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/TeamServicesSpec.scala
@@ -16,15 +16,10 @@
 
 package uk.gov.hmrc.cataloguefrontend
 
-import java.time.ZoneOffset
-
 import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.scalatest.BeforeAndAfter
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.DateHelper._
@@ -32,33 +27,15 @@ import uk.gov.hmrc.cataloguefrontend.JsonData._
 import uk.gov.hmrc.cataloguefrontend.connector.UserManagementConnector.TeamMember
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
+import java.time.ZoneOffset
 import scala.collection.JavaConverters._
 import scala.io.Source
 
-class TeamServicesSpec extends UnitSpec with BeforeAndAfter with GuiceOneServerPerSuite with WireMockEndpoints {
+class TeamServicesSpec extends UnitSpec with BeforeAndAfter with FakeApplicationBuilder {
 
   def asDocument(html: String): Document = Jsoup.parse(html)
 
   val umpFrontPageUrl = "http://some.ump.fontpage.com"
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.teams-and-repositories.host"  -> host,
-        "microservice.services.teams-and-repositories.port"  -> endpointPort,
-        "microservice.services.service-dependencies.port"    -> endpointPort,
-        "microservice.services.service-dependencies.host"    -> host,
-        "microservice.services.leak-detection.port"          -> endpointPort,
-        "microservice.services.leak-detection.host"          -> host,
-        "microservice.services.user-management.url"          -> endpointMockUrl,
-        "usermanagement.portal.url"                          -> "http://usermanagement/link",
-        "microservice.services.user-management.frontPageUrl" -> umpFrontPageUrl,
-        "play.ws.ssl.loose.acceptAnyCertificate"             -> true,
-        "play.http.requestHandler"                           -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                        -> false,
-        "team.hideArchivedRepositories"                      -> true
-      )
-      .build()
 
   private[this] lazy val WS           = app.injector.instanceOf[WSClient]
   private[this] lazy val viewMessages = app.injector.instanceOf[ViewMessages]

--- a/test/uk/gov/hmrc/cataloguefrontend/TeamsSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/TeamsSpec.scala
@@ -16,28 +16,14 @@
 
 package uk.gov.hmrc.cataloguefrontend
 
-import java.time.{LocalDateTime, ZoneOffset}
-
 import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.scalatest.BeforeAndAfter
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
-class TeamsSpec extends UnitSpec with BeforeAndAfter with GuiceOneServerPerSuite with WireMockEndpoints {
+import java.time.{LocalDateTime, ZoneOffset}
 
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(Map(
-        "microservice.services.teams-and-repositories.port" -> endpointPort,
-        "microservice.services.teams-and-repositories.host" -> host,
-        "play.ws.ssl.loose.acceptAnyCertificate"            -> true,
-        "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                       -> false
-      ))
-      .build()
+class TeamsSpec extends UnitSpec with BeforeAndAfter with FakeApplicationBuilder {
 
   private[this] lazy val WS = app.injector.instanceOf[WSClient]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/ShutterGroupsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/ShutterGroupsConnectorSpec.scala
@@ -18,28 +18,14 @@ package uk.gov.hmrc.cataloguefrontend.connector
 
 import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.scalatest.EitherValues
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.cataloguefrontend.FakeApplicationBuilder
 import uk.gov.hmrc.cataloguefrontend.shuttering.{ShutterGroup, ShutterGroupsConnector}
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 
 class ShutterGroupsConnectorSpec
     extends UnitSpec
-    with GuiceOneServerPerSuite
-    with WireMockEndpoints
+    with FakeApplicationBuilder
     with EitherValues {
-
-  override def fakeApplication: Application = new GuiceApplicationBuilder()
-    .disable(classOf[com.kenshoo.play.metrics.PlayModule])
-    .configure(Map(
-      "github.open.api.rawurl"     -> endpointMockUrl,
-      "github.open.api.token"      -> "",
-      "play.http.requestHandler"   -> "play.api.http.DefaultHttpRequestHandler",
-      "metrics.jvm"                -> false
-    ))
-    .build()
 
   private lazy val shutterGroupsConnnector = app.injector.instanceOf[ShutterGroupsConnector]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/TeamsAndRepositoriesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/TeamsAndRepositoriesConnectorSpec.scala
@@ -20,27 +20,23 @@ import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.mockito.MockitoSugar
 import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Millis, Span}
-import org.scalatest.{BeforeAndAfter, EitherValues, OptionValues}
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Span}
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
+import org.scalatest.{BeforeAndAfter, EitherValues, OptionValues}
 import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import uk.gov.hmrc.cataloguefrontend.connector.model.TeamName
 import uk.gov.hmrc.cataloguefrontend.model.Environment
-import uk.gov.hmrc.cataloguefrontend.{JsonData, WireMockEndpoints}
-import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import uk.gov.hmrc.cataloguefrontend.{FakeApplicationBuilder, JsonData}
+import uk.gov.hmrc.play.HeaderCarrierConverter
 
 class TeamsAndRepositoriesConnectorSpec
     extends AnyWordSpec
     with Matchers
     with BeforeAndAfter
     with ScalaFutures
-    with GuiceOneServerPerSuite
-    with WireMockEndpoints
+    with FakeApplicationBuilder
     with TypeCheckedTripleEquals
     with OptionValues
     with EitherValues
@@ -49,16 +45,6 @@ class TeamsAndRepositoriesConnectorSpec
   import JsonData.{createdAt, lastActiveAt}
 
   implicit val defaultPatienceConfig: PatienceConfig = PatienceConfig(Span(200, Millis), Span(15, Millis))
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.teams-and-repositories.host" -> host,
-        "microservice.services.teams-and-repositories.port" -> endpointPort,
-        "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                       -> false
-      )
-      .build()
 
   private lazy val teamsAndRepositoriesConnector: TeamsAndRepositoriesConnector =
     app.injector.instanceOf[TeamsAndRepositoriesConnector]

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -52,7 +52,7 @@ class HealthIndicatorsConnectorSpec
     "return a repository rating when given a valid repository name" in {
       serviceEndpoint(
         GET,
-        "/repositories/team-indicator-dashboard-frontend",
+        "/health-indicators/repositories/team-indicator-dashboard-frontend",
         willRespondWith = (200, Some(testJson))
       )
 
@@ -80,7 +80,7 @@ class HealthIndicatorsConnectorSpec
     "return None when repository is not found" in {
       serviceEndpoint(
         GET,
-        "/repositories/team-indicator-dashboard-frontend",
+        "/health-indicators/repositories/team-indicator-dashboard-frontend",
         willRespondWith = (
           404,
           None

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -1,0 +1,117 @@
+package uk.gov.hmrc.cataloguefrontend.healthindicators
+
+import com.github.tomakehurst.wiremock.http.RequestMethod.GET
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.http.HeaderCarrier
+
+
+class HealthIndicatorsConnectorSpec
+  extends AnyWordSpec
+  with Matchers
+  with GuiceOneAppPerSuite
+  with WireMockEndpoints
+  with OptionValues {
+
+  private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+  override def fakeApplication: Application =
+    new GuiceApplicationBuilder()
+      .disable(classOf[com.kenshoo.play.metrics.PlayModule])
+      .configure(
+        Map(
+          "microservice.services.health-indicators.port" -> endpointPort,
+          "microservice.services.health-indicators.host" -> host,
+          "metrics.jvm" -> false
+        ))
+      .build()
+
+
+  private lazy val healthIndicatorsConnector = app.injector.instanceOf[HealthIndicatorsConnector]
+
+  "getHealthIndicators()" should {
+    "return a repository rating when given a valid repository name" in {
+      serviceEndpoint(
+        GET,
+        "/repositories/team-indicator-dashboard-frontend",
+        willRespondWith = (
+          200,
+          Some(testJson
+          ))
+      )
+
+      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend")
+        .futureValue
+        .value
+
+      val ratings = Seq(
+        Rating("BobbyRule", -400,
+          Seq(
+            Score(-100, "frontend-bootstrap - Bug in Metrics Reporting", None),
+            Score(-100,  "frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)", None)
+          )),
+        Rating("LeakDetection", 0, Seq()),
+        Rating("ReadMe", -50, Seq(Score(-50, "No Readme defined", None))))
+
+      val expectedResponse = RepositoryRating("team-indicator-dashboard-frontend", -450, Some(ratings))
+
+      response shouldBe expectedResponse
+    }
+
+    "return None when repository is not found" in {
+      serviceEndpoint(
+        GET,
+        "/repositories/team-indicator-dashboard-frontend",
+        willRespondWith = (
+          404,
+          None
+      ))
+
+      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend")
+        .futureValue
+
+      response shouldBe None
+    }
+  }
+
+  private val testJson: String = """{
+                   |  "repositoryName": "team-indicator-dashboard-frontend",
+                   |  "repositoryScore": -450,
+                   |  "ratings": [
+                   |    {
+                   |      "ratingType": "BobbyRule",
+                   |      "ratingScore": -400,
+                   |      "breakdown": [
+                   |        {
+                   |          "points": -100,
+                   |          "description": "frontend-bootstrap - Bug in Metrics Reporting"
+                   |        },
+                   |        {
+                   |          "points": -100,
+                   |          "description": "frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)"
+                   |        }
+                   |      ]
+                   |    },
+                   |    {
+                   |      "ratingType": "LeakDetection",
+                   |      "ratingScore": 0,
+                   |      "breakdown": []
+                   |    },
+                   |    {
+                   |      "ratingType": "ReadMe",
+                   |      "ratingScore": -50,
+                   |      "breakdown": [
+                   |        {
+                   |          "points": -50,
+                   |          "description": "No Readme defined"
+                   |        }
+                   |      ]
+                   |    }
+                   |  ]
+                   |}""".stripMargin
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.cataloguefrontend.healthindicators
 
 import com.github.tomakehurst.wiremock.http.RequestMethod.GET

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -11,13 +11,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
 import uk.gov.hmrc.http.HeaderCarrier
 
-
-class HealthIndicatorsConnectorSpec
-  extends AnyWordSpec
-  with Matchers
-  with GuiceOneAppPerSuite
-  with WireMockEndpoints
-  with OptionValues {
+class HealthIndicatorsConnectorSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with WireMockEndpoints with OptionValues {
 
   private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
   override def fakeApplication: Application =
@@ -27,10 +21,9 @@ class HealthIndicatorsConnectorSpec
         Map(
           "microservice.services.health-indicators.port" -> endpointPort,
           "microservice.services.health-indicators.host" -> host,
-          "metrics.jvm" -> false
+          "metrics.jvm"                                  -> false
         ))
       .build()
-
 
   private lazy val healthIndicatorsConnector = app.injector.instanceOf[HealthIndicatorsConnector]
 
@@ -39,24 +32,23 @@ class HealthIndicatorsConnectorSpec
       serviceEndpoint(
         GET,
         "/repositories/team-indicator-dashboard-frontend",
-        willRespondWith = (
-          200,
-          Some(testJson
-          ))
+        willRespondWith = (200, Some(testJson))
       )
 
-      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend")
-        .futureValue
-        .value
+      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend").futureValue.value
 
       val ratings = Seq(
-        Rating("BobbyRule", -400,
+        Rating(
+          "BobbyRule",
+          -400,
           Seq(
             Score(-100, "frontend-bootstrap - Bug in Metrics Reporting", None),
-            Score(-100,  "frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)", None)
-          )),
+            Score(-100, "frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)", None)
+          )
+        ),
         Rating("LeakDetection", 0, Seq()),
-        Rating("ReadMe", -50, Seq(Score(-50, "No Readme defined", None))))
+        Rating("ReadMe", -50, Seq(Score(-50, "No Readme defined", None)))
+      )
 
       val expectedResponse = RepositoryRating("team-indicator-dashboard-frontend", -450, Some(ratings))
 
@@ -70,10 +62,9 @@ class HealthIndicatorsConnectorSpec
         willRespondWith = (
           404,
           None
-      ))
+        ))
 
-      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend")
-        .futureValue
+      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend").futureValue
 
       response shouldBe None
     }

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -27,7 +27,12 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
 import uk.gov.hmrc.http.HeaderCarrier
 
-class HealthIndicatorsConnectorSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite with WireMockEndpoints with OptionValues {
+class HealthIndicatorsConnectorSpec
+  extends AnyWordSpec
+    with Matchers
+    with GuiceOneAppPerSuite
+    with WireMockEndpoints
+    with OptionValues {
 
   private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
   override def fakeApplication: Application =
@@ -51,7 +56,8 @@ class HealthIndicatorsConnectorSpec extends AnyWordSpec with Matchers with Guice
         willRespondWith = (200, Some(testJson))
       )
 
-      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend").futureValue.value
+      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend")
+        .futureValue.value
 
       val ratings = Seq(
         Rating(
@@ -80,7 +86,9 @@ class HealthIndicatorsConnectorSpec extends AnyWordSpec with Matchers with Guice
           None
         ))
 
-      val response = healthIndicatorsConnector.getHealthIndicators("team-indicator-dashboard-frontend").futureValue
+      val response = healthIndicatorsConnector
+        .getHealthIndicators("team-indicator-dashboard-frontend")
+        .futureValue
 
       response shouldBe None
     }

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -21,31 +21,18 @@ import org.scalatest.OptionValues
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneAppPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
-import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.cataloguefrontend.FakeApplicationBuilder
 import uk.gov.hmrc.cataloguefrontend.healthindicators.RatingType.{BobbyRule, LeakDetection, ReadMe}
 import uk.gov.hmrc.http.HeaderCarrier
 
 class HealthIndicatorsConnectorSpec
   extends AnyWordSpec
     with Matchers
-    with GuiceOneAppPerSuite
-    with WireMockEndpoints
-    with OptionValues {
+    with OptionValues
+    with FakeApplicationBuilder{
 
   private implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .disable(classOf[com.kenshoo.play.metrics.PlayModule])
-      .configure(
-        Map(
-          "microservice.services.health-indicators.port" -> endpointPort,
-          "microservice.services.health-indicators.host" -> host,
-          "metrics.jvm"                                  -> false
-        ))
-      .build()
+
 
   private lazy val healthIndicatorsConnector = app.injector.instanceOf[HealthIndicatorsConnector]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -25,6 +25,7 @@ import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.cataloguefrontend.healthindicators.RatingType.{BobbyRule, LeakDetection, ReadMe}
 import uk.gov.hmrc.http.HeaderCarrier
 
 class HealthIndicatorsConnectorSpec
@@ -61,15 +62,15 @@ class HealthIndicatorsConnectorSpec
 
       val ratings = Seq(
         Rating(
-          "BobbyRule",
+          BobbyRule,
           -400,
           Seq(
             Score(-100, "frontend-bootstrap - Bug in Metrics Reporting", None),
             Score(-100, "frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)", None)
           )
         ),
-        Rating("LeakDetection", 0, Seq()),
-        Rating("ReadMe", -50, Seq(Score(-50, "No Readme defined", None)))
+        Rating(LeakDetection, 0, Seq()),
+        Rating(ReadMe, -50, Seq(Score(-50, "No Readme defined", None)))
       )
 
       val expectedResponse = RepositoryRating("team-indicator-dashboard-frontend", -450, Some(ratings))

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsConnectorSpec.scala
@@ -73,7 +73,7 @@ class HealthIndicatorsConnectorSpec
         Rating(ReadMe, -50, Seq(Score(-50, "No Readme defined", None)))
       )
 
-      val expectedResponse = RepositoryRating("team-indicator-dashboard-frontend", -450, Some(ratings))
+      val expectedResponse = RepositoryRating("team-indicator-dashboard-frontend", -450, ratings)
 
       response shouldBe expectedResponse
     }

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
@@ -56,7 +56,7 @@ class HealthIndicatorsControllerSpec
     "respond with status 200 and contain specified elements" in new Setup {
       serviceEndpoint(
         GET,
-        "/repositories/team-indicator-dashboard-frontend",
+        "/health-indicators/repositories/team-indicator-dashboard-frontend",
         willRespondWith = (
           200,
           Some(testJson)
@@ -73,7 +73,7 @@ class HealthIndicatorsControllerSpec
     "respond with status 404 when repository is not found" in new Setup {
       serviceEndpoint(
         GET,
-        "/repositories/team-indicator-dashboard-frontend",
+        "health-indicators/repositories/team-indicator-dashboard-frontend",
         willRespondWith = (
           404,
           None

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
@@ -1,0 +1,119 @@
+package uk.gov.hmrc.cataloguefrontend.healthindicators
+
+import com.github.tomakehurst.wiremock.http.RequestMethod.GET
+import org.mockito.MockitoSugar
+import org.scalatest.OptionValues
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.{WSClient, WSResponse}
+import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.http.HeaderCarrier
+
+class HealthIndicatorsControllerSpec
+  extends AnyWordSpec
+  with Matchers
+  with MockitoSugar
+  with GuiceOneServerPerSuite
+  with WireMockEndpoints
+  with OptionValues
+  with ScalaFutures
+  {
+
+    implicit val defaultPatience =
+      PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+
+  override def fakeApplication: Application =
+    new GuiceApplicationBuilder()
+      .configure(
+        Map(
+          "microservice.services.health-indicators.port" -> endpointPort,
+          "microservice.services.health-indicators.host" -> host,
+          "metrics.jvm" -> false
+        ))
+      .build()
+
+  "HealthIndicatorsController" should {
+    "respond with status 200 and contain specified elements" in new Setup {
+      serviceEndpoint(
+        GET,
+        "/repositories/team-indicator-dashboard-frontend",
+        willRespondWith = (
+          200,
+          Some(testJson)
+        ))
+
+      private val response: WSResponse =
+        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend")
+          .get
+          .futureValue
+
+      response.status shouldBe 200
+      response.body should include("""frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)""")
+      response.body should include("""<td id="section_2_row_0_col_2">No Readme defined</td>""")
+    }
+
+    "respond with status 404 when repository is not found" in new Setup {
+      serviceEndpoint(
+        GET,
+        "/repositories/team-indicator-dashboard-frontend",
+        willRespondWith = (
+          404,
+          None
+        ))
+
+      private val response: WSResponse =
+        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend")
+          .get
+          .futureValue
+
+      response.status shouldBe 404
+    }
+  }
+
+    private[this] trait Setup {
+      lazy val ws = app.injector.instanceOf[WSClient]
+      implicit val hc: HeaderCarrier = HeaderCarrier()
+      val testJson: String =
+        """{
+          |  "repositoryName": "team-indicator-dashboard-frontend",
+          |  "repositoryScore": -450,
+          |  "ratings": [
+          |    {
+          |      "ratingType": "BobbyRule",
+          |      "ratingScore": -400,
+          |      "breakdown": [
+          |        {
+          |          "points": -100,
+          |          "description": "frontend-bootstrap - Bug in Metrics Reporting"
+          |        },
+          |        {
+          |          "points": -100,
+          |          "description": "frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)"
+          |        }
+          |      ]
+          |    },
+          |    {
+          |      "ratingType": "LeakDetection",
+          |      "ratingScore": 0,
+          |      "breakdown": []
+          |    },
+          |    {
+          |      "ratingType": "ReadMe",
+          |      "ratingScore": -50,
+          |      "breakdown": [
+          |        {
+          |          "points": -50,
+          |          "description": "No Readme defined"
+          |        }
+          |      ]
+          |    }
+          |  ]
+          |}""".stripMargin
+    }
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
@@ -63,6 +63,14 @@ class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with Mock
     }
   }
 
+  "getScoreColour()" should {
+    "return correct class string" in {
+      HealthIndicatorsController.getScoreColour(100) shouldBe "repo-score-green"
+      HealthIndicatorsController.getScoreColour(0) shouldBe "repo-score-amber"
+      HealthIndicatorsController.getScoreColour(100) shouldBe "repo-score-red"
+    }
+  }
+
   private[this] trait Setup {
     lazy val ws                    = app.injector.instanceOf[WSClient]
     implicit val hc: HeaderCarrier = HeaderCarrier()

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
@@ -3,8 +3,7 @@ package uk.gov.hmrc.cataloguefrontend.healthindicators
 import com.github.tomakehurst.wiremock.http.RequestMethod.GET
 import org.mockito.MockitoSugar
 import org.scalatest.OptionValues
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpec
@@ -15,18 +14,10 @@ import play.api.libs.ws.{WSClient, WSResponse}
 import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
 import uk.gov.hmrc.http.HeaderCarrier
 
-class HealthIndicatorsControllerSpec
-  extends AnyWordSpec
-  with Matchers
-  with MockitoSugar
-  with GuiceOneServerPerSuite
-  with WireMockEndpoints
-  with OptionValues
-  with ScalaFutures
-  {
+class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with MockitoSugar with GuiceOneServerPerSuite with WireMockEndpoints with OptionValues with ScalaFutures {
 
-    implicit val defaultPatience =
-      PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
 
   override def fakeApplication: Application =
     new GuiceApplicationBuilder()
@@ -34,7 +25,7 @@ class HealthIndicatorsControllerSpec
         Map(
           "microservice.services.health-indicators.port" -> endpointPort,
           "microservice.services.health-indicators.host" -> host,
-          "metrics.jvm" -> false
+          "metrics.jvm"                                  -> false
         ))
       .build()
 
@@ -49,13 +40,11 @@ class HealthIndicatorsControllerSpec
         ))
 
       private val response: WSResponse =
-        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend")
-          .get
-          .futureValue
+        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend").get.futureValue
 
       response.status shouldBe 200
-      response.body should include("""frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)""")
-      response.body should include("""<td id="section_2_row_0_col_2">No Readme defined</td>""")
+      response.body   should include("""frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)""")
+      response.body   should include("""<td id="section_2_row_0_col_2">No Readme defined</td>""")
     }
 
     "respond with status 404 when repository is not found" in new Setup {
@@ -68,19 +57,17 @@ class HealthIndicatorsControllerSpec
         ))
 
       private val response: WSResponse =
-        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend")
-          .get
-          .futureValue
+        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend").get.futureValue
 
       response.status shouldBe 404
     }
   }
 
-    private[this] trait Setup {
-      lazy val ws = app.injector.instanceOf[WSClient]
-      implicit val hc: HeaderCarrier = HeaderCarrier()
-      val testJson: String =
-        """{
+  private[this] trait Setup {
+    lazy val ws                    = app.injector.instanceOf[WSClient]
+    implicit val hc: HeaderCarrier = HeaderCarrier()
+    val testJson: String =
+      """{
           |  "repositoryName": "team-indicator-dashboard-frontend",
           |  "repositoryScore": -450,
           |  "ratings": [
@@ -115,5 +102,5 @@ class HealthIndicatorsControllerSpec
           |    }
           |  ]
           |}""".stripMargin
-    }
+  }
 }

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
@@ -23,34 +23,20 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpec
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws.{WSClient, WSResponse}
-import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.cataloguefrontend.FakeApplicationBuilder
 import uk.gov.hmrc.http.HeaderCarrier
 
 class HealthIndicatorsControllerSpec
   extends AnyWordSpec
     with Matchers
     with MockitoSugar
-    with GuiceOneServerPerSuite
-    with WireMockEndpoints
+    with FakeApplicationBuilder
     with OptionValues
     with ScalaFutures {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        Map(
-          "microservice.services.health-indicators.port" -> endpointPort,
-          "microservice.services.health-indicators.host" -> host,
-          "metrics.jvm"                                  -> false
-        ))
-      .build()
 
   "HealthIndicatorsController" should {
     "respond with status 200 and contain specified elements" in new Setup {

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
@@ -30,7 +30,14 @@ import play.api.libs.ws.{WSClient, WSResponse}
 import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
 import uk.gov.hmrc.http.HeaderCarrier
 
-class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with MockitoSugar with GuiceOneServerPerSuite with WireMockEndpoints with OptionValues with ScalaFutures {
+class HealthIndicatorsControllerSpec
+  extends AnyWordSpec
+    with Matchers
+    with MockitoSugar
+    with GuiceOneServerPerSuite
+    with WireMockEndpoints
+    with OptionValues
+    with ScalaFutures {
 
   implicit val defaultPatience =
     PatienceConfig(timeout = Span(5, Seconds), interval = Span(500, Millis))
@@ -56,7 +63,7 @@ class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with Mock
         ))
 
       private val response: WSResponse =
-        ws.url(s"http://localhost:$port/service/team-indicator-dashboard-frontend/health").get.futureValue
+        ws.url(s"http://localhost:$port/service/team-indicator-dashboard-frontend/health-indicators").get.futureValue
 
       response.status shouldBe 200
       response.body   should include("""frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)""")
@@ -73,7 +80,7 @@ class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with Mock
         ))
 
       private val response: WSResponse =
-        ws.url(s"http://localhost:$port/service/team-indicator-dashboard-frontend/health").get.futureValue
+        ws.url(s"http://localhost:$port/service/team-indicator-dashboard-frontend/health-indicators").get.futureValue
 
       response.status shouldBe 404
     }

--- a/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/healthindicators/HealthIndicatorsControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.cataloguefrontend.healthindicators
 
 import com.github.tomakehurst.wiremock.http.RequestMethod.GET
@@ -40,7 +56,7 @@ class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with Mock
         ))
 
       private val response: WSResponse =
-        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend").get.futureValue
+        ws.url(s"http://localhost:$port/service/team-indicator-dashboard-frontend/health").get.futureValue
 
       response.status shouldBe 200
       response.body   should include("""frontend-bootstrap - Critical security upgrade: [CVE](https://confluence.tools.tax.service.gov.uk/x/sNukC)""")
@@ -57,7 +73,7 @@ class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with Mock
         ))
 
       private val response: WSResponse =
-        ws.url(s"http://localhost:$port/test/health-indicators/team-indicator-dashboard-frontend").get.futureValue
+        ws.url(s"http://localhost:$port/service/team-indicator-dashboard-frontend/health").get.futureValue
 
       response.status shouldBe 404
     }
@@ -67,7 +83,7 @@ class HealthIndicatorsControllerSpec extends AnyWordSpec with Matchers with Mock
     "return correct class string" in {
       HealthIndicatorsController.getScoreColour(100) shouldBe "repo-score-green"
       HealthIndicatorsController.getScoreColour(0) shouldBe "repo-score-amber"
-      HealthIndicatorsController.getScoreColour(100) shouldBe "repo-score-red"
+      HealthIndicatorsController.getScoreColour(-100) shouldBe "repo-score-red"
     }
   }
 

--- a/test/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/ReleasesConnectorSpec.scala
@@ -16,31 +16,18 @@
 
 package uk.gov.hmrc.cataloguefrontend.whatsrunningwhere
 
-import java.time.Instant
-
 import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.scalatest._
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
-import uk.gov.hmrc.cataloguefrontend.WireMockEndpoints
+import uk.gov.hmrc.cataloguefrontend.FakeApplicationBuilder
 import uk.gov.hmrc.cataloguefrontend.model.Environment
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 
-class ReleasesConnectorSpec extends UnitSpec with GuiceOneServerPerSuite with WireMockEndpoints with EitherValues {
+import java.time.Instant
 
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .disable(classOf[com.kenshoo.play.metrics.PlayModule])
-      .configure(Map(
-        "microservice.services.releases-api.port" -> endpointPort,
-        "microservice.services.releases-api.host" -> host,
-        "play.http.requestHandler"                -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                             -> false
-      ))
-      .build()
+class ReleasesConnectorSpec extends UnitSpec with FakeApplicationBuilder with EitherValues {
+
 
   private lazy val releasesConnector = app.injector.instanceOf[ReleasesConnector]
 

--- a/test/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/WhatsRunningWhereSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/whatsrunningwhere/WhatsRunningWhereSpec.scala
@@ -18,27 +18,11 @@ package uk.gov.hmrc.cataloguefrontend.whatsrunningwhere
 
 import com.github.tomakehurst.wiremock.http.RequestMethod._
 import org.scalatest._
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.ws._
-import uk.gov.hmrc.cataloguefrontend.{JsonData, WireMockEndpoints}
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
+import uk.gov.hmrc.cataloguefrontend.{FakeApplicationBuilder, JsonData, WireMockEndpoints}
 
-class WhatsRunningWhereSpec extends UnitSpec with BeforeAndAfter with GuiceOneServerPerSuite with WireMockEndpoints {
-
-  override def fakeApplication: Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "microservice.services.releases-api.host"           -> host,
-        "microservice.services.releases-api.port"           -> endpointPort,
-        "microservice.services.teams-and-repositories.host" -> host,
-        "microservice.services.teams-and-repositories.port" -> endpointPort,
-        "play.ws.ssl.loose.acceptAnyCertificate"            -> true,
-        "play.http.requestHandler"                          -> "play.api.http.DefaultHttpRequestHandler",
-        "metrics.jvm"                                       -> false
-      )
-      .build()
+class WhatsRunningWhereSpec extends UnitSpec with BeforeAndAfter with FakeApplicationBuilder with WireMockEndpoints {
 
   private[this] lazy val WS = app.injector.instanceOf[WSClient]
 


### PR DESCRIPTION
This is a rough first draft of the service health indicators page for a repo, nothing here is set in stone and would appreciate feed back on the code and UI.

I have kept the new page on a test endpoint as it won't be linked to through the nav bar for the time being. 

Screen shot of added page: https://user-images.githubusercontent.com/68235822/107976182-12c92a00-6fb1-11eb-92a9-45602e132f4d.png

