### PR TITLE
Provide service cost estimates

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
@@ -55,8 +55,6 @@ class ConfigConnector @Inject() (
   )(implicit hc: HeaderCarrier): Future[Option[DeploymentConfig]] = {
     implicit val dcr = DeploymentConfig.reads
     http
-      .GET[DeploymentConfig](s"$serviceConfigsBaseUrl/deployment-config/${environment.asString}/$service")
-      .map(Some(_))
-      .recover { case _ => None }
+      .GET[Option[DeploymentConfig]](s"$serviceConfigsBaseUrl/deployment-config/${environment.asString}/$service")
   }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyRuleSet
 import uk.gov.hmrc.cataloguefrontend.model.Environment
 import uk.gov.hmrc.cataloguefrontend.service.ConfigService._
 import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.DeploymentConfig
-import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads, StringContextOps}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,14 +39,14 @@ class ConfigConnector @Inject() (
   implicit val cbkr = ConfigByKey.reads
 
   def configByEnv(service: String)(implicit hc: HeaderCarrier): Future[ConfigByEnvironment] =
-    http.GET[ConfigByEnvironment](s"$serviceConfigsBaseUrl/config-by-env/$service")
+    http.GET[ConfigByEnvironment](url"$serviceConfigsBaseUrl/config-by-env/$service")
 
   def configByKey(service: String)(implicit hc: HeaderCarrier): Future[ConfigByKey] =
-    http.GET[ConfigByKey](s"$serviceConfigsBaseUrl/config-by-key/$service")
+    http.GET[ConfigByKey](url"$serviceConfigsBaseUrl/config-by-key/$service")
 
   def bobbyRules()(implicit hc: HeaderCarrier): Future[BobbyRuleSet] = {
     implicit val brsr = BobbyRuleSet.reads
-    http.GET[BobbyRuleSet](s"$serviceConfigsBaseUrl/bobby/rules")
+    http.GET[BobbyRuleSet](url"$serviceConfigsBaseUrl/bobby/rules")
   }
 
   def deploymentConfig(
@@ -54,7 +54,8 @@ class ConfigConnector @Inject() (
     environment: Environment
   )(implicit hc: HeaderCarrier): Future[Option[DeploymentConfig]] = {
     implicit val dcr = DeploymentConfig.reads
-    http
-      .GET[Option[DeploymentConfig]](s"$serviceConfigsBaseUrl/deployment-config/${environment.asString}/$service")
+    http.GET[Option[DeploymentConfig]](
+      url"$serviceConfigsBaseUrl/deployment-config/${environment.asString}/$service"
+    )
   }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnector.scala
@@ -18,7 +18,9 @@ package uk.gov.hmrc.cataloguefrontend.connector
 
 import javax.inject.{Inject, Singleton}
 import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyRuleSet
+import uk.gov.hmrc.cataloguefrontend.model.Environment
 import uk.gov.hmrc.cataloguefrontend.service.ConfigService._
+import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.DeploymentConfig
 import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpReads}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
@@ -45,5 +47,16 @@ class ConfigConnector @Inject() (
   def bobbyRules()(implicit hc: HeaderCarrier): Future[BobbyRuleSet] = {
     implicit val brsr = BobbyRuleSet.reads
     http.GET[BobbyRuleSet](s"$serviceConfigsBaseUrl/bobby/rules")
+  }
+
+  def deploymentConfig(
+    service: String,
+    environment: Environment
+  )(implicit hc: HeaderCarrier): Future[Option[DeploymentConfig]] = {
+    implicit val dcr = DeploymentConfig.reads
+    http
+      .GET[DeploymentConfig](s"$serviceConfigsBaseUrl/deployment-config/${environment.asString}/$service")
+      .map(Some(_))
+      .recover { case _ => None }
   }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -27,7 +27,7 @@ import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-final class CostEstimationService @Inject() (configConnector: ConfigConnector) {
+class CostEstimationService @Inject() (configConnector: ConfigConnector) {
 
   def estimateServiceCost(
     service: String,

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -22,7 +22,6 @@ import uk.gov.hmrc.cataloguefrontend.model.Environment
 import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.{CostEstimation, DeploymentConfig}
 import uk.gov.hmrc.http.HeaderCarrier
 
-import java.util.Locale
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -63,11 +62,6 @@ object CostEstimationService {
 
     lazy val yearlyCostUsd: Double =
       totalInstances * 120
-
-    lazy val yearlyCostFormatted: String = {
-      val formattter = java.text.NumberFormat.getCurrencyInstance(Locale.US)
-      formattter.format(yearlyCostUsd)
-    }
   }
 
   object CostEstimation {

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.service
+
+import play.api.libs.json.{Json, Reads}
+import uk.gov.hmrc.cataloguefrontend.connector.ConfigConnector
+import uk.gov.hmrc.cataloguefrontend.model.Environment
+import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.{CostEstimation, DeploymentConfig}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import java.util.Locale
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+final class CostEstimationService @Inject() (configConnector: ConfigConnector) {
+
+  def estimateServiceCost(
+    service: String,
+    environments: Seq[Environment]
+  )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[CostEstimation] =
+    Future
+      .traverse(environments)(environment =>
+        configConnector
+          .deploymentConfig(service, environment)
+          .map(deploymentConfig => (environment, deploymentConfig.getOrElse(DeploymentConfig(0, 0))))
+      )
+      .map(deploymentConfigByEnvironment =>
+        CostEstimation
+          .fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment.toMap)
+      )
+}
+
+object CostEstimationService {
+
+  type DeploymentConfigByEnvironment = Map[Environment, DeploymentConfig]
+
+  final case class DeploymentConfig(slots: Int, instances: Int)
+
+  object DeploymentConfig {
+    val reads: Reads[DeploymentConfig] = Json.reads[DeploymentConfig]
+  }
+
+  final case class CostEstimation(totalSlots: Int) {
+
+    val yearlyCost: Double =
+      totalSlots * 650.0
+
+    val yearlyCostFormatted: String = {
+      val formattter = java.text.NumberFormat.getCurrencyInstance(Locale.UK)
+      formattter.format(yearlyCost)
+    }
+  }
+
+  object CostEstimation {
+
+    def fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment: DeploymentConfigByEnvironment): CostEstimation = {
+      val totalSlots =
+        deploymentConfigByEnvironment.values
+          .map(deploymentConfig => deploymentConfig.slots * deploymentConfig.instances)
+          .sum
+
+      CostEstimation(totalSlots)
+    }
+  }
+}

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -37,7 +37,7 @@ class CostEstimationService @Inject() (configConnector: ConfigConnector) {
       .traverse(environments)(environment =>
         configConnector
           .deploymentConfig(service, environment)
-          .map(deploymentConfig => (environment, deploymentConfig.getOrElse(DeploymentConfig(0, 0))))
+          .map(deploymentConfig => (environment, deploymentConfig.getOrElse(DeploymentConfig.empty)))
       )
       .map(deploymentConfigByEnvironment =>
         CostEstimation
@@ -52,7 +52,11 @@ object CostEstimationService {
   final case class DeploymentConfig(slots: Int, instances: Int)
 
   object DeploymentConfig {
-    val reads: Reads[DeploymentConfig] = Json.reads[DeploymentConfig]
+    val empty: DeploymentConfig =
+      DeploymentConfig(slots = 0, instances = 0)
+
+    val reads: Reads[DeploymentConfig] =
+      Json.reads[DeploymentConfig]
   }
 
   final case class CostEstimation(totalSlots: Int) {

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -61,10 +61,10 @@ object CostEstimationService {
 
   final case class CostEstimation(totalSlots: Int) {
 
-    val yearlyCost: Double =
+    lazy val yearlyCost: Double =
       totalSlots * 650.0
 
-    val yearlyCostFormatted: String = {
+    lazy val yearlyCostFormatted: String = {
       val formattter = java.text.NumberFormat.getCurrencyInstance(Locale.UK)
       formattter.format(yearlyCost)
     }

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -59,26 +59,26 @@ object CostEstimationService {
       Json.reads[DeploymentConfig]
   }
 
-  final case class CostEstimation(totalSlots: Int) {
+  final case class CostEstimation(totalInstances: Int) {
 
-    lazy val yearlyCost: Double =
-      totalSlots * 650.0
+    lazy val yearlyCostUsd: Double =
+      totalInstances * 120
 
     lazy val yearlyCostFormatted: String = {
-      val formattter = java.text.NumberFormat.getCurrencyInstance(Locale.UK)
-      formattter.format(yearlyCost)
+      val formattter = java.text.NumberFormat.getCurrencyInstance(Locale.US)
+      formattter.format(yearlyCostUsd)
     }
   }
 
   object CostEstimation {
 
     def fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment: DeploymentConfigByEnvironment): CostEstimation = {
-      val totalSlots =
+      val totalInstances =
         deploymentConfigByEnvironment.values
-          .map(deploymentConfig => deploymentConfig.slots * deploymentConfig.instances)
+          .map(_.instances)
           .sum
 
-      CostEstimation(totalSlots)
+      CostEstimation(totalInstances)
     }
   }
 }

--- a/app/uk/gov/hmrc/cataloguefrontend/util/CurrencyFormatter.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/util/CurrencyFormatter.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.util
+
+import java.util.Locale
+
+object CurrencyFormatter {
+
+  private val currencyFormatterUsd =
+    java.text.NumberFormat.getCurrencyInstance(Locale.US)
+
+  def formatUsd(value: Double): String =
+    currencyFormatterUsd.format(value)
+}

--- a/app/views/ServiceInfoPage.scala.html
+++ b/app/views/ServiceInfoPage.scala.html
@@ -22,6 +22,7 @@
 @import uk.gov.hmrc.cataloguefrontend.connector.model.Dependencies
 @import uk.gov.hmrc.cataloguefrontend.model.{Environment, SlugInfoFlag}
 @import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.{EnvironmentRoute, ServiceRoutes}
+@import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.CostEstimation
 @import uk.gov.hmrc.cataloguefrontend.{EnvData, ServiceInfoView, ViewMessages}
 @import views.partials.githubBadgeType
 
@@ -30,6 +31,7 @@
 @(
   serviceName                  : String,
   repositoryDetails            : RepositoryDetails,
+  costEstimation               : CostEstimation,
   optLegacyLatestDependencies  : Option[Dependencies],
   repositoryCreationDate       : LocalDateTime,
   envDatas                     : Map[SlugInfoFlag, EnvData],
@@ -59,11 +61,13 @@
     <section class="section-wrapper">
 
         <div class="row">
-            <div class="col-md-12">
+            <div class="col-md-7">
                 @partials.details(repositoryDetails)
             </div>
+            <div class="col-md-5">
+                @partials.costEstimation(costEstimation)
+            </div>
         </div>
-
         @productionEnvironmentRoute.map { envRoute =>
             <div class="row">
                 <div class="col-md-12">

--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -1,0 +1,30 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.CostEstimation
+
+@(costEstimation: CostEstimation)
+<div id="cost-estimation">
+    <div class="board">
+        <h3 class="board__heading">Estimated Cost</h3>
+        <div class="board__body">
+            <p><b>@costEstimation.yearlyCostFormatted</b> per year.</p>
+            <p>This estimate is based on a usage of @costEstimation.totalSlots slots across all environments.</p>
+            <p>If your team is responsible for this service, and its cost exceeds your expectations, then you should aim
+               to scale it down.</p>
+        </div>
+    </div>
+</div>

--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -22,7 +22,7 @@
         <h3 class="board__heading">Estimated Cost</h3>
         <div class="board__body">
             <p><b>@costEstimation.yearlyCostFormatted</b> per year.</p>
-            <p>This estimate is based on a usage of @costEstimation.totalSlots slots across all environments.</p>
+            <p>This estimate is based on a usage of @costEstimation.totalInstances slots across all environments.</p>
             <p>If your team is responsible for this service, and its cost exceeds your expectations, then you should aim
                to scale it down.</p>
         </div>

--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -15,13 +15,14 @@
  *@
 
 @import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.CostEstimation
+@import uk.gov.hmrc.cataloguefrontend.util.CurrencyFormatter.formatUsd
 
 @(costEstimation: CostEstimation)
 <div id="cost-estimation">
     <div class="board">
         <h3 class="board__heading">Estimated Cost</h3>
         <div class="board__body">
-            <p><b>@costEstimation.yearlyCostFormatted</b> per year.</p>
+            <p><b>@formatUsd(costEstimation.yearlyCostUsd)</b> per year.</p>
             <p>This estimate is based on a usage of @costEstimation.totalInstances slots across all environments.</p>
             <p>If your team is responsible for this service, and its cost exceeds your expectations, then you should aim
                to scale it down.</p>

--- a/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
@@ -249,6 +249,7 @@ class DigitalServicePageSpec extends UnitSpec with FakeApplicationBuilder with M
       userManagementConnector       = userManagementConnectorMock,
       teamsAndRepositoriesConnector = teamsAndRepositoriesConnectorMock,
       configService                 = mock[ConfigService],
+      costEstimationService         = mock[CostEstimationService],
       routeRulesService             = mock[RouteRulesService],
       serviceDependencyConnector    = mock[ServiceDependenciesConnector],
       leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/LibrariesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/LibrariesSpec.scala
@@ -21,7 +21,7 @@ import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector._
-import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
+import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterService
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
@@ -46,6 +46,7 @@ class LibrariesSpec extends UnitSpec with MockitoSugar {
     userManagementConnector       = mock[UserManagementConnector],
     teamsAndRepositoriesConnector = mock[TeamsAndRepositoriesConnector],
     configService                 = mock[ConfigService],
+    costEstimationService         = mock[CostEstimationService],
     routeRulesService             = mock[RouteRulesService],
     serviceDependencyConnector    = mock[ServiceDependenciesConnector],
     leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/PrototypesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/PrototypesSpec.scala
@@ -21,7 +21,7 @@ import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector._
-import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
+import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterService
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
@@ -46,6 +46,7 @@ class PrototypesSpec extends UnitSpec with MockitoSugar {
     userManagementConnector       = mock[UserManagementConnector],
     teamsAndRepositoriesConnector = mock[TeamsAndRepositoriesConnector],
     configService                 = mock[ConfigService],
+    costEstimationService         = mock[CostEstimationService],
     routeRulesService             = mock[RouteRulesService],
     serviceDependencyConnector    = mock[ServiceDependenciesConnector],
     leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/ServicesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/ServicesSpec.scala
@@ -21,7 +21,7 @@ import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector._
-import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
+import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterService
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
@@ -46,6 +46,7 @@ class ServicesSpec extends UnitSpec with MockitoSugar {
     userManagementConnector       = mock[UserManagementConnector],
     teamsAndRepositoriesConnector = mock[TeamsAndRepositoriesConnector],
     configService                 = mock[ConfigService],
+    costEstimationService         = mock[CostEstimationService],
     routeRulesService             = mock[RouteRulesService],
     serviceDependencyConnector    = mock[ServiceDependenciesConnector],
     leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnectorSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/connector/ConfigConnectorSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.connector
+
+import com.github.tomakehurst.wiremock.client.WireMock._
+import play.api.Configuration
+import uk.gov.hmrc.cataloguefrontend.model.Environment
+import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.DeploymentConfig
+import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.http.test.{HttpClientSupport, WireMockSupport}
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+final class ConfigConnectorSpec
+  extends UnitSpec
+    with HttpClientSupport
+    with WireMockSupport {
+
+  val servicesConfig =
+    new ServicesConfig(
+      Configuration(
+        "microservice.services.service-configs.host" -> wireMockHost,
+        "microservice.services.service-configs.port" -> wireMockPort
+      )
+    )
+
+  val configConnector =
+    new ConfigConnector(httpClient, servicesConfig)
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  "deploymentConfig" should {
+    "return the deployment configuration for a service in an environment" in {
+      stubFor(
+        get(urlEqualTo("/deployment-config/production/some-service"))
+          .willReturn(aResponse().withBody("""{ "slots": 11, "instances": 3 }"""))
+      )
+
+      val deploymentConfig =
+        configConnector
+          .deploymentConfig("some-service", Environment.Production)
+          .futureValue
+
+      deploymentConfig shouldBe Some(DeploymentConfig(slots = 11, instances = 3))
+    }
+
+    "return None when the deployment configuration cannot be found" in {
+      val deploymentConfig =
+        configConnector
+          .deploymentConfig("some-service", Environment.Production)
+          .futureValue
+
+      deploymentConfig shouldBe None
+    }
+  }
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
@@ -121,11 +121,11 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
         )
 
       val actualEstimatedCost =
-        CostEstimation.fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment).yearlyCostFormatted
+        CostEstimation.fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment).yearlyCostUsd
 
       // Yearly cost is estimated as a service's total instances across all environments multiplied by $120
       // 2 + 1 + 3 * 120.0
-      val expectedEstimatedCost = "$720.00"
+      val expectedEstimatedCost = 720.0
 
       actualEstimatedCost shouldBe expectedEstimatedCost
     }

--- a/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.cataloguefrontend.service
+
+import org.mockito.scalatest.MockitoSugar
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.cataloguefrontend.connector.ConfigConnector
+import uk.gov.hmrc.cataloguefrontend.model.Environment
+import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.{CostEstimation, DeploymentConfig, DeploymentConfigByEnvironment}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with ScalaFutures with MockitoSugar {
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  "Service" should {
+    "produce a cost estimate for a service in all requested environments in which it's deployed" in {
+      val stubs: DeploymentConfigByEnvironment =
+        Map(
+          (Environment.Development, DeploymentConfig(3, 1)),
+          (Environment.Integration, DeploymentConfig(3, 1)),
+          (Environment.QA, DeploymentConfig(3, 1)),
+          (Environment.Staging, DeploymentConfig(3, 1)),
+          (Environment.ExternalTest, DeploymentConfig(3, 1)),
+          (Environment.Production, DeploymentConfig(11, 3))
+        )
+
+      val configConnector =
+        stubConfigConnector(
+          service = "some-service",
+          stubs = stubs,
+          missingEnvironments = Set.empty
+        )
+
+      val costEstimationService =
+        new CostEstimationService(configConnector)
+
+      val costEstimation =
+        costEstimationService.estimateServiceCost("some-service", stubs.keySet.toSeq)
+
+      val expectedCostEstimation =
+        CostEstimation.fromDeploymentConfigByEnvironment(stubs)
+
+      costEstimation.futureValue shouldBe expectedCostEstimation
+    }
+
+    "disregard services which are not deployed in requested environments" in {
+      val stubs: DeploymentConfigByEnvironment =
+        Map((Environment.Production, DeploymentConfig(11, 3)))
+
+      val missingEnvironments: Set[Environment] =
+        Set(Environment.QA, Environment.Staging)
+
+      val configConnector =
+        stubConfigConnector(
+          service = "some-service",
+          stubs = stubs,
+          missingEnvironments = missingEnvironments
+        )
+
+      val costEstimationService =
+        new CostEstimationService(configConnector)
+
+      val costEstimation =
+        costEstimationService.estimateServiceCost("some-service", (stubs.keySet ++ missingEnvironments).toSeq)
+
+      val expectedCostEstimation =
+        CostEstimation.fromDeploymentConfigByEnvironment(stubs)
+
+      costEstimation.futureValue shouldBe expectedCostEstimation
+    }
+
+    "produce a cost estimate of zero for a service which is not deployed in a requested environment" in {
+      val missingEnvironments: Set[Environment] =
+        Set(Environment.QA, Environment.Staging, Environment.Production)
+
+      val configConnector =
+        stubConfigConnector(
+          service = "some-service",
+          stubs = Map.empty,
+          missingEnvironments = missingEnvironments
+        )
+
+      val costEstimationService =
+        new CostEstimationService(configConnector)
+
+      val costEstimation =
+        costEstimationService.estimateServiceCost("some-service", missingEnvironments.toSeq)
+
+      val expectedCostEstimation =
+        CostEstimation(0)
+
+      costEstimation.futureValue shouldBe expectedCostEstimation
+    }
+
+    "estimate cost as a function of a service's total slots across all environments" in {
+      val deploymentConfigByEnvironment: DeploymentConfigByEnvironment =
+        Map(
+          (Environment.Development, DeploymentConfig(5, 2)),
+          (Environment.QA, DeploymentConfig(3, 1)),
+          (Environment.Production, DeploymentConfig(10, 3))
+        )
+
+      val actualEstimatedCost =
+        CostEstimation.fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment).yearlyCostFormatted
+
+      // Yearly cost is estimated as a service's total slot usage across all environments multiplied by £650
+      // (5 * 2 + 3 * 1 + 10 * 3) * 650.0
+      val expectedEstimatedCost = "£27,950.00"
+
+      actualEstimatedCost shouldBe expectedEstimatedCost
+    }
+  }
+
+  private def stubConfigConnector(
+    service: String,
+    stubs: DeploymentConfigByEnvironment,
+    missingEnvironments: Set[Environment]
+  ): ConfigConnector = {
+    val configConnector =
+      mock[ConfigConnector]
+
+    stubs.foreach {
+      case (environment, deploymentConfig) =>
+        when(configConnector.deploymentConfig(service, environment))
+          .thenReturn(Future.successful(Some(deploymentConfig)))
+    }
+
+    missingEnvironments.foreach { environment =>
+      when(configConnector.deploymentConfig(service, environment))
+        .thenReturn(Future.successful(None))
+    }
+
+    configConnector
+  }
+}

--- a/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
@@ -123,9 +123,9 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
       val actualEstimatedCost =
         CostEstimation.fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment).yearlyCostFormatted
 
-      // Yearly cost is estimated as a service's total slot usage across all environments multiplied by £650
-      // (5 * 2 + 3 * 1 + 10 * 3) * 650.0
-      val expectedEstimatedCost = "£27,950.00"
+      // Yearly cost is estimated as a service's total instances across all environments multiplied by $120
+      // 2 + 1 + 3 * 120.0
+      val expectedEstimatedCost = "$720.00"
 
       actualEstimatedCost shouldBe expectedEstimatedCost
     }


### PR DESCRIPTION
Estimated yearly cost (total ~slots~ instances across all environments * ~£650.00~ $120) is now displayed on the `ServiceInfoPage`, e.g. on `/repositories/repository-name` where `repository-name` is the name of a service.

Here's an example view:

![Screenshot 2021-12-13 at 16 10 25](https://user-images.githubusercontent.com/3607811/145848147-f246411c-c9ce-409d-bfb4-5d8b3886a145.png)

--

I've still not been able to spin this up locally with an export of the Mongo DB in order to kick the tyres properly, so I'll hold off on merging this until I can do that (waiting for an automated job to fire tomorrow morning to finalise my access.)