### PR TITLE
Fix cost estimation wording

### DIFF
--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -23,7 +23,7 @@
         <h3 class="board__heading">Estimated Cost</h3>
         <div class="board__body">
             <p><b>@formatUsd(costEstimation.yearlyCostUsd)</b> per year.</p>
-            <p>This estimate is based on a usage of @costEstimation.totalInstances slots across all environments.</p>
+            <p>This estimate is based on a usage of @costEstimation.totalInstances instances across all environments.</p>
             <p>If your team is responsible for this service, and its cost exceeds your expectations, then you should aim
                to scale it down.</p>
         </div>


### PR DESCRIPTION
Cost estimation is no longer based on slot usage, but on instance usage.
This change updates the explaining text in the relevant view
accordingly.