### PR TITLE
Cost estimates include per-environment breakdowns

### DIFF
--- a/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/CatalogueController.scala
@@ -28,8 +28,7 @@ import uk.gov.hmrc.cataloguefrontend.connector.UserManagementConnector.UMPError
 import uk.gov.hmrc.cataloguefrontend.connector.model.{Dependency, TeamName, Version}
 import uk.gov.hmrc.cataloguefrontend.model.{Environment, SlugInfoFlag}
 import uk.gov.hmrc.cataloguefrontend.service.ConfigService.ArtifactNameResult.{ArtifactNameError, ArtifactNameFound, ArtifactNameNotFound}
-import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.ServiceCostEstimate
-import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
+import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimateConfig, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.{ShutterService, ShutterState, ShutterType}
 import uk.gov.hmrc.cataloguefrontend.util.MarkdownLoader
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
@@ -58,6 +57,7 @@ class CatalogueController @Inject() (
   teamsAndRepositoriesConnector: TeamsAndRepositoriesConnector,
   configService                : ConfigService,
   costEstimationService        : CostEstimationService,
+  serviceCostEstimateConfig    : CostEstimateConfig,
   routeRulesService            : RouteRulesService,
   serviceDependenciesConnector : ServiceDependenciesConnector,
   leakDetectionService         : LeakDetectionService,
@@ -314,9 +314,6 @@ class CatalogueController @Inject() (
 
     val costEstimationEnvironments =
       repositoryDetails.environments.getOrElse(Seq.empty).map(_.environment)
-
-    val serviceCostEstimateConfig =
-      ServiceCostEstimate.Config.get()
 
     (
       teamsAndRepositoriesConnector.lookupLink(repositoryName),

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -64,8 +64,7 @@ object CostEstimationService {
   final case class ServiceCostEstimate(forEnvironments: List[ServiceCostEstimate.ForEnvironment]) {
 
     lazy val summary: ServiceCostEstimate.Summary =
-      forEnvironments
-        .foldLeft(Summary.zero)((summary, forEnv) => summary + Summary(forEnv.slots, forEnv.yearlyCostGbp))
+      forEnvironments.map(_.summary).fold(Summary.zero)(_ + _)
   }
 
   object ServiceCostEstimate {
@@ -88,7 +87,11 @@ object CostEstimationService {
       environment: Environment,
       slots: Int,
       yearlyCostGbp: Double
-    )
+    ) {
+
+      def summary: Summary =
+        Summary(slots, yearlyCostGbp)
+    }
 
     final case class Summary(totalSlots: Int, totalYearlyCostGbp: Double) {
       def +(other: Summary): Summary =

--- a/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
+++ b/app/uk/gov/hmrc/cataloguefrontend/service/CostEstimationService.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.cataloguefrontend.service
 import play.api.libs.json.{Json, Reads}
 import uk.gov.hmrc.cataloguefrontend.connector.ConfigConnector
 import uk.gov.hmrc.cataloguefrontend.model.Environment
-import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.{CostEstimation, DeploymentConfig}
+import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.ServiceCostEstimate.Summary
+import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.{DeploymentConfig, ServiceCostEstimate}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
@@ -31,7 +32,7 @@ class CostEstimationService @Inject() (configConnector: ConfigConnector) {
   def estimateServiceCost(
     service: String,
     environments: Seq[Environment]
-  )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[CostEstimation] =
+  )(implicit ec: ExecutionContext, hc: HeaderCarrier): Future[ServiceCostEstimate] =
     Future
       .traverse(environments)(environment =>
         configConnector
@@ -39,7 +40,7 @@ class CostEstimationService @Inject() (configConnector: ConfigConnector) {
           .map(deploymentConfig => (environment, deploymentConfig.getOrElse(DeploymentConfig.empty)))
       )
       .map(deploymentConfigByEnvironment =>
-        CostEstimation
+        ServiceCostEstimate
           .fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment.toMap)
       )
 }
@@ -58,21 +59,44 @@ object CostEstimationService {
       Json.reads[DeploymentConfig]
   }
 
-  final case class CostEstimation(totalSlots: Int) {
+  final case class ServiceCostEstimate(forEnvironments: List[ServiceCostEstimate.ForEnvironment]) {
 
-    lazy val yearlyCostGbp: Double =
-      totalSlots * 650
+    lazy val summary: ServiceCostEstimate.Summary =
+      forEnvironments
+        .foldLeft(Summary.zero)((summary, forEnv) => summary + Summary(forEnv.slots, forEnv.yearlyCostGbp))
   }
 
-  object CostEstimation {
+  object ServiceCostEstimate {
 
-    def fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment: DeploymentConfigByEnvironment): CostEstimation = {
-      val totalSlots =
-        deploymentConfigByEnvironment.values
-          .map(c => c.slots * c.instances)
-          .sum
+    val slotCostPerYear: Double = 650
 
-      CostEstimation(totalSlots)
+    def fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment: DeploymentConfigByEnvironment): ServiceCostEstimate =
+      ServiceCostEstimate {
+        deploymentConfigByEnvironment
+          .collect { case (env, config) if config.slots > 0 && config.instances > 0 =>
+            val yearlyCostGbp =
+              config.slots * config.instances * slotCostPerYear
+            ForEnvironment(env, config.slots, yearlyCostGbp)
+          }
+          .toList
+          .sortBy(_.environment)
+      }
+
+    final case class ForEnvironment(
+      environment: Environment,
+      slots: Int,
+      yearlyCostGbp: Double
+    )
+
+    final case class Summary(totalSlots: Int, totalYearlyCostGbp: Double) {
+      def +(other: Summary): Summary =
+        Summary(totalSlots + other.totalSlots, totalYearlyCostGbp + other.totalYearlyCostGbp)
+    }
+
+    object Summary {
+
+      val zero: Summary =
+        Summary(totalSlots = 0, totalYearlyCostGbp = 0)
     }
   }
 }

--- a/app/views/ServiceInfoPage.scala.html
+++ b/app/views/ServiceInfoPage.scala.html
@@ -22,7 +22,7 @@
 @import uk.gov.hmrc.cataloguefrontend.connector.model.Dependencies
 @import uk.gov.hmrc.cataloguefrontend.model.{Environment, SlugInfoFlag}
 @import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.{EnvironmentRoute, ServiceRoutes}
-@import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.CostEstimation
+@import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.ServiceCostEstimate
 @import uk.gov.hmrc.cataloguefrontend.{EnvData, ViewMessages}
 @import uk.gov.hmrc.cataloguefrontend.CatalogueFrontendSwitches
 @import views.partials.githubBadgeType
@@ -36,7 +36,7 @@
 @(
   serviceName                  : String,
   repositoryDetails            : RepositoryDetails,
-  costEstimation               : CostEstimation,
+  costEstimation               : ServiceCostEstimate,
   repositoryCreationDate       : LocalDateTime,
   envDatas                     : Map[SlugInfoFlag, EnvData],
   linkToLeakDetection          : Option[String],

--- a/app/views/ServiceInfoPage.scala.html
+++ b/app/views/ServiceInfoPage.scala.html
@@ -23,6 +23,7 @@
 @import uk.gov.hmrc.cataloguefrontend.model.{Environment, SlugInfoFlag}
 @import uk.gov.hmrc.cataloguefrontend.service.RouteRulesService.{EnvironmentRoute, ServiceRoutes}
 @import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.ServiceCostEstimate
+@import uk.gov.hmrc.cataloguefrontend.service.CostEstimateConfig
 @import uk.gov.hmrc.cataloguefrontend.{EnvData, ViewMessages}
 @import uk.gov.hmrc.cataloguefrontend.CatalogueFrontendSwitches
 @import views.partials.githubBadgeType
@@ -37,7 +38,7 @@
   serviceName                  : String,
   repositoryDetails            : RepositoryDetails,
   costEstimate                 : ServiceCostEstimate,
-  costEstimateConfig           : ServiceCostEstimate.Config,
+  costEstimateConfig           : CostEstimateConfig,
   repositoryCreationDate       : LocalDateTime,
   envDatas                     : Map[SlugInfoFlag, EnvData],
   linkToLeakDetection          : Option[String],

--- a/app/views/ServiceInfoPage.scala.html
+++ b/app/views/ServiceInfoPage.scala.html
@@ -36,7 +36,8 @@
 @(
   serviceName                  : String,
   repositoryDetails            : RepositoryDetails,
-  costEstimation               : ServiceCostEstimate,
+  costEstimate                 : ServiceCostEstimate,
+  costEstimateConfig           : ServiceCostEstimate.Config,
   repositoryCreationDate       : LocalDateTime,
   envDatas                     : Map[SlugInfoFlag, EnvData],
   linkToLeakDetection          : Option[String],
@@ -70,7 +71,7 @@
                   @partials.details(repositoryDetails)
               </div>
               <div class="col-md-6">
-                  @partials.costEstimation(costEstimation)
+                  @partials.costEstimation(costEstimate, costEstimateConfig)
               </div>
             } else {
               <div class="col-md-12">

--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -17,7 +17,7 @@
 @import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.ServiceCostEstimate
 @import uk.gov.hmrc.cataloguefrontend.util.CurrencyFormatter.formatGbp
 
-@(serviceCostEstimate: ServiceCostEstimate)
+@(serviceCostEstimate: ServiceCostEstimate, serviceCostEstimateConfig: ServiceCostEstimate.Config)
 <div id="cost-estimation">
     <div class="board">
         <h3 class="board__heading">Estimated Cost</h3>
@@ -25,9 +25,10 @@
             <p><b>@formatGbp(serviceCostEstimate.summary.totalYearlyCostGbp)</b> per year.</p>
             <p>This is based on a usage of @serviceCostEstimate.summary.totalSlots slots across all environments, where
                <em data-toggle="tooltip"
-                     title="We arrive at this figure, very roughly, by dividing MDTP's yearly AWS spend of £5.4M by the
-                            total number of slots used by all services across all environments">
-                   each slot is estimated to cost £650.00 per year
+                     title="We arrive at this figure, very roughly, by dividing MDTP's yearly AWS spend of
+                            @serviceCostEstimateConfig.totalAwsCostPerYear by the total number of slots used by all
+                            services across all environments">
+                   each slot is estimated to cost @formatGbp(serviceCostEstimateConfig.slotCostPerYear) per year
                </em>.</p>
             <div id="chart" />
         </div>

--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -14,16 +14,16 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.CostEstimation
+@import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.ServiceCostEstimate
 @import uk.gov.hmrc.cataloguefrontend.util.CurrencyFormatter.formatGbp
 
-@(costEstimation: CostEstimation)
+@(serviceCostEstimate: ServiceCostEstimate)
 <div id="cost-estimation">
     <div class="board">
         <h3 class="board__heading">Estimated Cost</h3>
         <div class="board__body">
-            <p><b>@formatGbp(costEstimation.yearlyCostGbp)</b> per year.</p>
-            <p>This is based on a usage of @costEstimation.totalSlots slots across all environments, where
+            <p><b>@formatGbp(serviceCostEstimate.summary.totalYearlyCostGbp)</b> per year.</p>
+            <p>This is based on a usage of @serviceCostEstimate.summary.totalSlots slots across all environments, where
                <em data-toggle="tooltip"
                      title="We arrive at this figure, very roughly, by dividing MDTP's yearly AWS spend of £5.4M by the
                             total number of slots used by all services across all environments">

--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -29,6 +29,27 @@
                             total number of slots used by all services across all environments">
                    each slot is estimated to cost £650.00 per year
                </em>.</p>
+            <div id="chart" />
         </div>
     </div>
 </div>
+
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script type="text/javascript">
+      google.charts.load("current", {packages:["corechart"]});
+      google.charts.setOnLoadCallback(drawChart);
+
+      function drawChart() {
+        var data = google.visualization.arrayToDataTable([
+          ['Environment',   'Estimated Cost'],
+          @for(e <- serviceCostEstimate.forEnvironments) {
+            ['@e.environment.asString', { v: @e.yearlyCostGbp, f: "@formatGbp(e.yearlyCostGbp) (slots = @e.slots)" } ],
+          }
+        ]);
+
+        var options = {};
+
+        var chart = new google.visualization.PieChart(document.getElementById('chart'));
+        chart.draw(data, options);
+      }
+</script>

--- a/app/views/partials/costEstimation.scala.html
+++ b/app/views/partials/costEstimation.scala.html
@@ -15,9 +15,10 @@
  *@
 
 @import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.ServiceCostEstimate
+@import uk.gov.hmrc.cataloguefrontend.service.CostEstimateConfig
 @import uk.gov.hmrc.cataloguefrontend.util.CurrencyFormatter.formatGbp
 
-@(serviceCostEstimate: ServiceCostEstimate, serviceCostEstimateConfig: ServiceCostEstimate.Config)
+@(serviceCostEstimate: ServiceCostEstimate, serviceCostEstimateConfig: CostEstimateConfig)
 <div id="cost-estimation">
     <div class="board">
         <h3 class="board__heading">Estimated Cost</h3>

--- a/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/DigitalServicePageSpec.scala
@@ -250,6 +250,7 @@ class DigitalServicePageSpec extends UnitSpec with FakeApplicationBuilder with M
       teamsAndRepositoriesConnector = teamsAndRepositoriesConnectorMock,
       configService                 = mock[ConfigService],
       costEstimationService         = mock[CostEstimationService],
+      serviceCostEstimateConfig     = mock[CostEstimateConfig],
       routeRulesService             = mock[RouteRulesService],
       serviceDependenciesConnector  = mock[ServiceDependenciesConnector],
       leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/LibrariesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/LibrariesSpec.scala
@@ -21,7 +21,7 @@ import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector._
-import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
+import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimateConfig, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterService
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
@@ -47,6 +47,7 @@ class LibrariesSpec extends UnitSpec with MockitoSugar {
     teamsAndRepositoriesConnector = mock[TeamsAndRepositoriesConnector],
     configService                 = mock[ConfigService],
     costEstimationService         = mock[CostEstimationService],
+    serviceCostEstimateConfig     = mock[CostEstimateConfig],
     routeRulesService             = mock[RouteRulesService],
     serviceDependenciesConnector  = mock[ServiceDependenciesConnector],
     leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/PrototypesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/PrototypesSpec.scala
@@ -21,7 +21,7 @@ import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector._
-import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
+import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimateConfig, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterService
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
@@ -47,6 +47,7 @@ class PrototypesSpec extends UnitSpec with MockitoSugar {
     teamsAndRepositoriesConnector = mock[TeamsAndRepositoriesConnector],
     configService                 = mock[ConfigService],
     costEstimationService         = mock[CostEstimationService],
+    serviceCostEstimateConfig     = mock[CostEstimateConfig],
     routeRulesService             = mock[RouteRulesService],
     serviceDependenciesConnector  = mock[ServiceDependenciesConnector],
     leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/ServicesSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/ServicesSpec.scala
@@ -21,7 +21,7 @@ import play.api.Configuration
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.cataloguefrontend.connector._
-import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
+import uk.gov.hmrc.cataloguefrontend.service.{ConfigService, CostEstimateConfig, CostEstimationService, DefaultBranchesService, LeakDetectionService, RouteRulesService}
 import uk.gov.hmrc.cataloguefrontend.shuttering.ShutterService
 import uk.gov.hmrc.cataloguefrontend.util.UnitSpec
 import uk.gov.hmrc.cataloguefrontend.whatsrunningwhere.WhatsRunningWhereService
@@ -47,6 +47,7 @@ class ServicesSpec extends UnitSpec with MockitoSugar {
     teamsAndRepositoriesConnector = mock[TeamsAndRepositoriesConnector],
     configService                 = mock[ConfigService],
     costEstimationService         = mock[CostEstimationService],
+    serviceCostEstimateConfig     = mock[CostEstimateConfig],
     routeRulesService             = mock[RouteRulesService],
     serviceDependenciesConnector  = mock[ServiceDependenciesConnector],
     leakDetectionService          = mock[LeakDetectionService],

--- a/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
@@ -20,9 +20,10 @@ import org.mockito.scalatest.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import play.api.Configuration
 import uk.gov.hmrc.cataloguefrontend.connector.ConfigConnector
 import uk.gov.hmrc.cataloguefrontend.model.Environment
-import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.{ServiceCostEstimate, DeploymentConfig, DeploymentConfigByEnvironment}
+import uk.gov.hmrc.cataloguefrontend.service.CostEstimationService.{DeploymentConfig, DeploymentConfigByEnvironment, ServiceCostEstimate}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
@@ -160,5 +161,5 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
   }
 
   private lazy val costEstimateConfig =
-    ServiceCostEstimate.Config(650.00, "£5.4M")
+    new CostEstimateConfig(Configuration.empty)
 }

--- a/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
+++ b/test/uk/gov/hmrc/cataloguefrontend/service/CostEstimationServiceSpec.scala
@@ -55,10 +55,10 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
         new CostEstimationService(configConnector)
 
       val costEstimate =
-        costEstimationService.estimateServiceCost("some-service", stubs.keySet.toSeq)
+        costEstimationService.estimateServiceCost("some-service", stubs.keySet.toSeq, costEstimateConfig)
 
       val expectedCostEstimation =
-        ServiceCostEstimate.fromDeploymentConfigByEnvironment(stubs)
+        ServiceCostEstimate.fromDeploymentConfigByEnvironment(stubs, costEstimateConfig)
 
       costEstimate.futureValue shouldBe expectedCostEstimation
     }
@@ -81,10 +81,11 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
         new CostEstimationService(configConnector)
 
       val costEstimate =
-        costEstimationService.estimateServiceCost("some-service", (stubs.keySet ++ missingEnvironments).toSeq)
+        costEstimationService
+          .estimateServiceCost("some-service", (stubs.keySet ++ missingEnvironments).toSeq, costEstimateConfig)
 
       val expectedCostEstimate =
-        ServiceCostEstimate.fromDeploymentConfigByEnvironment(stubs)
+        ServiceCostEstimate.fromDeploymentConfigByEnvironment(stubs, costEstimateConfig)
 
       costEstimate.futureValue shouldBe expectedCostEstimate
     }
@@ -105,7 +106,7 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
 
       val costEstimateSummary =
         costEstimationService
-          .estimateServiceCost("some-service", missingEnvironments.toSeq)
+          .estimateServiceCost("some-service", missingEnvironments.toSeq, costEstimateConfig)
           .map(_.summary)
 
       val expectedCostEstimateSummary =
@@ -124,7 +125,7 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
 
       val actualEstimatedCost =
         ServiceCostEstimate
-          .fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment)
+          .fromDeploymentConfigByEnvironment(deploymentConfigByEnvironment, costEstimateConfig)
           .summary
           .totalYearlyCostGbp
 
@@ -157,4 +158,7 @@ final class CostEstimationServiceSpec extends AnyWordSpec with Matchers with Sca
 
     configConnector
   }
+
+  private lazy val costEstimateConfig =
+    ServiceCostEstimate.Config(650.00, "£5.4M")
 }


### PR DESCRIPTION
Looks a little something like this:
<img width="1174" alt="Screenshot 2022-01-10 at 16 04 18" src="https://user-images.githubusercontent.com/3607811/148805833-8cb3f0c5-8275-41dc-bc09-e9cb4ea78353.png">

