### PR TITLE
BDOG-1573 Fix chart flickering in Chrome

### DIFF
--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -90,6 +90,8 @@ img {
 svg:not(:root) {
   overflow: hidden; }
 
+svg > g:last-child > g.google-visualization-tooltip { pointer-events: none }
+
 figure {
   margin: 1em 40px; }
 

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -90,6 +90,8 @@ img {
 svg:not(:root) {
   overflow: hidden; }
 
+/* Fixes a Google Charts flickering-on-over issue outlined here:
+   https://github.com/google/google-visualization-issues/issues/2162 */
 svg > g:last-child > g.google-visualization-tooltip { pointer-events: none }
 
 figure {


### PR DESCRIPTION
Applies the fix detailed here:
https://github.com/google/google-visualization-issues/issues/2162