### PR TITLE
BAU Replace Request with RequestHeader in view templates

### DIFF
--- a/app/views/error_403_template.scala.html
+++ b/app/views/error_403_template.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@()(implicit request: Request[_])
+@()(implicit request: RequestHeader)
 
 @standard_layout("Forbidden") {
     <section class="section-wrapper">

--- a/app/views/error_404_template.scala.html
+++ b/app/views/error_404_template.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@()(implicit request: Request[_], messages: Messages)
+@()(implicit request: RequestHeader, messages: Messages)
 
 @standard_layout(Messages("global.error.pageNotFound404.title")) {
     <div id="error_content">

--- a/app/views/error_template.scala.html
+++ b/app/views/error_template.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_])
+@(pageTitle: String, heading: String, message: String)(implicit request: RequestHeader)
 
 @standard_layout(pageTitle) {
     <section class="section-wrapper">
@@ -24,4 +24,3 @@
         <p>If the problem persists, please get in touch with #team-platops on Slack</p>
     </section>
 }
-

--- a/app/views/partials/with_username.scala.html
+++ b/app/views/partials/with_username.scala.html
@@ -16,7 +16,7 @@
 
 @import uk.gov.hmrc.cataloguefrontend.auth.AuthController
 
-@(ifLoggedIn: String => Html)(ifNotLoggedIn: => Html)(implicit request: Request[_])
+@(ifLoggedIn: String => Html)(ifNotLoggedIn: => Html)(implicit request: RequestHeader)
 
 @{
   request

--- a/app/views/standard_layout.scala.html
+++ b/app/views/standard_layout.scala.html
@@ -29,7 +29,7 @@
   head       : Html   = Html(""),
   preContent : Html   = Html(""),
   postContent: Html   = Html("")
-)(content: Html)(implicit request: Request[_])
+)(content: Html)(implicit request: RequestHeader)
 <!DOCTYPE html>
 <html>
     <head>
@@ -111,7 +111,7 @@
                             <li><a href="@HealthIndicatorsController.indicatorsForRepoType()">Health-Indicators</a></li>
                             <li><a href="@uk.gov.hmrc.cataloguefrontend.platforminitiatives.routes.PlatformInitiativesController.platformInitiatives()">Platform Initiatives</a></li>
                             <li role="separator" class="divider"></li>
-                            <li><a href="@appRoutes.BobbyExplorerController.list">Bobby Explorer</a></li>
+                            <li><a href="@appRoutes.BobbyExplorerController.list()">Bobby Explorer</a></li>
                             <li role="separator" class="divider"></li>
                             <li><a href="@uk.gov.hmrc.cataloguefrontend.leakdetection.routes.LeakDetectionController.ruleSummaries">Leak Detection - Rules</a></li>
                             <li><a href="@uk.gov.hmrc.cataloguefrontend.leakdetection.routes.LeakDetectionController.repoSummaries(false, false, true)">Leak Detection - Repositories</a></li>


### PR DESCRIPTION
It's not required, and the body is not actually available for error templates