### PR TITLE
BDOG-2036: Fix sorting bug, and change nested table colour.

### DIFF
--- a/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
+++ b/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
@@ -79,8 +79,8 @@
                         <tr>
                             <th></th>
                             <th class="col-xs-2"><button class="sort no-border" data-sort="vuln-id">Vulnerability id</button></th>
-                            <th class="col-xs-2"><button class="sort no-border" data-sort="vulnerable-component-name">Vulnerable Component</button></th>
-                            <th class="col-xs-5"><button class="sort no-border" data-sort="description">Description</button></th>
+                            <th class="col-xs-2"><button class="no-border" data-sort="vulnerable-component-name">Vulnerable Component</button></th>
+                            <th class="col-xs-5"><button class="no-border" data-sort="description">Description</button></th>
                             <th class="col-xs-1"><button class="sort no-border" data-sort="score">Score</button></th>
                             <th class="col-xs-1 text-center"><button class="sort no-border" data-sort="teams">Teams</button></th>
                             <th class="col-xs-1 text-center"><button class="sort no-border" data-sort="services">Services</button></th>
@@ -93,7 +93,7 @@
             </div>
 
         <script>
-            var options = {valueNames: ['vuln-id', 'vulnerable-component-name', 'description', 'score', 'teams', 'services'],
+            var options = {valueNames: ['vuln-id', 'score', 'teams', 'services'],
                 indexAsync: true};
                 vulnList = new List('vulnerabilities-list', options);
         </script>

--- a/app/views/vulnerabilities/VulnerabilityDetails.scala.html
+++ b/app/views/vulnerabilities/VulnerabilityDetails.scala.html
@@ -70,7 +70,7 @@
             <li class="col-xs-12">
                 <div><label>Vulnerability Occurrences: </label></div>
                 <div style="max-height: 305px; overflow-y: scroll">
-                <table class="table table-striped">
+                <table class="table">
                     <thead>
                         <tr>
                             <th class="col-xs-2">Service</th>


### PR DESCRIPTION
1. The table on this page consists of `groups` of two rows, the first is visible by default, and the second is expandable. List.js respects the sorting order for columns with one word (vuln-id), or numbers (score, teams, services). However when sorting on description or component path, the hidden child row would sometimes be sorted above the parent row, so when expanded, it would jump above. We don't need to sort by these columns anyway, so have removed from list.js config.

2. Changed nested table from striped to white, to make it easier to distinguish between an expanded section and the next row.