### PR TITLE
BDOG-2036 Fix CSS

### DIFF
--- a/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
+++ b/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
@@ -107,9 +107,9 @@
             <td class="vuln-id hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-expanded="false" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.id</td>
             <td class="vulnerable-component-name hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-expanded="false" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.vulnerableComponentName</td>
             <td class="assessment hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-expanded="false" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.assessment.getOrElse("")</td>
-            <td class="curation-status text-center"><div>@summary.distinctVulnerability.curationStatus.map(_.display).getOrElse("")</div></td>
+            <td class="curation-status text-center hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-expanded="false" aria-controls="collapsible-area-@summary.distinctVulnerability.id"><div>@summary.distinctVulnerability.curationStatus.map(_.display).getOrElse("")</div></td>
             <td class="score hand-pointer text-center" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-expanded="false" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.score.getOrElse("")</td>
-            <td class="services text-center"><div>@summary.occurrences.groupBy(_.service).size</div></td>
+            <td class="services text-center hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-expanded="false" aria-controls="collapsible-area-@summary.distinctVulnerability.id"><div>@summary.occurrences.groupBy(_.service).size</div></td>
         </tr>
         <tr id="collapsible-area-@summary.distinctVulnerability.id" class="collapse">
             @*Provide hidden fields in collapsable element so that list.js sorting doesn't break when some rows are expanded*@


### PR DESCRIPTION
Currently only certain columns show the hand-pointer when hovering over, meaning only certain columns can expand the collapsable row. This is inconsistent. Desired behaviour is that clicking anywhere on the parent row should expand the child row.