### PR TITLE
BDOG-2255 Show Vulnerable Component Name & Versions as a list

### DIFF
--- a/app/views/vulnerabilities/VulnerabilityDetails.scala.html
+++ b/app/views/vulnerabilities/VulnerabilityDetails.scala.html
@@ -26,19 +26,33 @@
     <div class="col-xs-12">
         <ul class="list list--minimal list-group row">
             <li class="col-xs-6">
-                <label>Vulnerable Component Version: </label>
-                @vuln.distinctVulnerability.vulnerableComponentVersion
+                <label>Description: </label>
+                <div style="height: 140px; overflow-y: auto; overflow-x: hidden">
+                    <div>@vuln.distinctVulnerability.description</div>
+                </div>
             </li>
             <li class="col-xs-6">
                 <label>Date published: </label>
                 @defining(new SimpleDateFormat("dd/MM/yyyy")) {fmt =>
-                    @fmt.format(Date.from(vuln.distinctVulnerability.publishedDate))
+                @fmt.format(Date.from(vuln.distinctVulnerability.publishedDate))
                 }
             </li>
             <li class="col-xs-6">
-                <label>Description: </label>
+                <label>Vulnerable components on platform: </label>
                 <div style="height: 140px; overflow-y: auto; overflow-x: hidden">
-                    <div>@vuln.distinctVulnerability.description</div>
+                    <ul>
+                        @vuln.distinctVulnerability.vulnerableComponents.sortWith(_.version > _.version).map{vc =>
+                            <li style="display: list-item; list-style-type: disc">
+                                @if(vc.component.startsWith("gav")) {
+                                    <a href="@{appRoutes.DependencyExplorerController.search.toString}?group=@{vc.group}&artefact=@{vc.artefact}&versionRange=[0.0.0,)&team=&flag=latest&scope=compile">@vc.component</a>
+                                    :
+                                    <a href="@{appRoutes.DependencyExplorerController.search.toString}?group=@{vc.group}&artefact=@{vc.artefact}&versionRange=[@{vc.cleansedVersion},@{vc.cleansedVersion}]&team=&flag=latest&scope=compile">@vc.version</a>
+                                } else {
+                                    @vc.component:@vc.version
+                                }
+                            </li>
+                        }
+                    </ul>
                 </div>
             </li>
             <li class="col-xs-6">


### PR DESCRIPTION
Previously an incorrect assumption was made that there would be a unique vulnerable component name and version for each distinct Vulnerability. Have fixed this by showing the data as a scrollable list, and making it link to the dependency explorer page.