### PR TITLE
BDOG-2553: clarify truncated service relationship section

### DIFF
--- a/app/views/partials/service_relationships.scala.html
+++ b/app/views/partials/service_relationships.scala.html
@@ -17,15 +17,19 @@
 @import uk.gov.hmrc.cataloguefrontend.service.ConfigService.ServiceRelationshipsWithHasRepo
 
 @(serviceRelationships: ServiceRelationshipsWithHasRepo)
+@hasTooManyRelationships = @{
+    serviceRelationships.size > 3
+}
 <div id="service_relationships">
     <div class="board">
         <h3 class="board__heading">
             Service Relationships
-            @if(serviceRelationships.size > 3) {
-                <a href="#" class="pull-right board-expand-link">See all</a>
+            @if(hasTooManyRelationships) {
+                <a href="#" title="See all" class="pull-right board-expand-link glyphicon glyphicon-chevron-down">
+                </a>
             }
         </h3>
-        <div class="board-grow">
+        <div class="board-grow @if(hasTooManyRelationships){ board-gradient }">
             <div class="board__body board-collapse">
                 <div class="row">
                     <div class="col-md-6">

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -11955,6 +11955,15 @@ section span.other-teams-message {
   height:120px; /* If you change this, change the corresponding smallHeight value in catalogue-frontend.css too */
 }
 
+.board-expand-link {
+  text-decoration: none !important;
+}
+
+.board-gradient {
+  mask: linear-gradient(#000 66%, #0000 100%);
+  -webkit-mask: linear-gradient(#000 66%, #0000 100%);
+}
+
 .indicator__title {
   margin-left: 1.0em;
   margin-bottom: 0;

--- a/public/catalogue-frontend.js
+++ b/public/catalogue-frontend.js
@@ -19,16 +19,21 @@ $(function() { //document ready event
   // Controls the expand/collapse of the what's new and blog post sections on the front page
   $('.board-expand-link').on('click',function(event) {
     event.preventDefault();
-    var growDiv     = $(this).parent().siblings('.board-grow').first();
+    let self = $(this);
+    var growDiv     = self.parent().siblings('.board-grow').first();
     var wrapper     = growDiv.find(".board-collapse");
     var smallHeight = 120; //Should match css value
 
     if (growDiv.height() > smallHeight) {
       growDiv.css("height",smallHeight + "px"); //Collapse to small height
-      $(this).text('See all');
+      growDiv.addClass("board-gradient"); //Add gradient mask
+      self.attr("title", "See all");
+      self.removeClass('glyphicon-chevron-up').addClass('glyphicon-chevron-down'); //Set expand icon
     } else {
       growDiv.css("height",wrapper.innerHeight() + "px"); //Expand to height of inner content
-      $(this).text('Collapse');
+      growDiv.removeClass("board-gradient"); //Remove gradient mask
+      self.attr("title", "Collapse");
+      self.removeClass('glyphicon-chevron-down').addClass('glyphicon-chevron-up'); //Set collapse icon
     }
   });
 });


### PR DESCRIPTION
The `Services Relationship` section on the [Service Catalogue](https://catalogue.tax.service.gov.uk/repositories/auth#service_relationships) page need to be presented in a way that, when truncation happens, it needs to be obvious to our users.

These changes involve applying a gradient mask to the related services lists and, also, the replacement of text with icons on the links that applies and removes the truncation.
![amended version with title on links](https://user-images.githubusercontent.com/1241373/232774104-ab543060-e747-4c5a-9d6f-08099b30cb28.png)


