### PR TITLE
BDOG-2489 Remove vulnerable component prefix (e.g. gav) from top leve…

### DIFF
--- a/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
+++ b/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
@@ -107,37 +107,39 @@
 }
 
 @vulnerabilitiesSummary(summary: VulnerabilitySummary) = {
-    <tr>
-        <td class="accordion-toggle collapsed hand-pointer " data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id"/>
-        <td class="vuln-id hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.id</td>
-        <td class="vulnerable-component-name hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.vulnerableComponentName</td>
-        <td class="assessment hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.assessment.getOrElse("")</td>
-        <td class="curation-status hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id"><div>@summary.distinctVulnerability.curationStatus.map(_.display).getOrElse("")</div></td>
-        <td class="score hand-pointer text-right" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.score.getOrElse("")</td>
-        <td class="services text-right hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id"><div>@summary.occurrences.groupBy(_.service).size</div></td>
-    </tr>
-    <tr id="collapsible-area-@summary.distinctVulnerability.id" class="collapse">
-        @*Provide hidden fields in collapsable element so that list.js sorting doesn't break when some rows are expanded*@
-        <td colspan="7">
-            <table>
-                <tbody class="list">
-                    <tr>
-                        <td class="hide vuln-id">@summary.distinctVulnerability.id</td>
-                        <td class="hide vulnerable-component-name">@summary.distinctVulnerability.vulnerableComponentName</td>
-                        <td class="hide assessment">@summary.distinctVulnerability.assessment.getOrElse("")</td>
-                        <td class="curation-status text-center hide"><div>@summary.distinctVulnerability.curationStatus.map(_.display).getOrElse("")</div></td>
-                        <td class="hide score text-center">@summary.distinctVulnerability.score.getOrElse("")</td>
-                        <td class="services text-center hide"><div>@summary.occurrences.groupBy(_.service).size</div></td>
-                    </tr>
-                    <tr>
-                        <td colspan="6">
-                            @VulnerabilityDetails(summary)
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
-        </td>
-    </tr>
+    @defining(summary.distinctVulnerability.vulnerableComponentName.split("://")) { splitVulnerableComponent =>
+        <tr>
+            <td class="accordion-toggle collapsed hand-pointer " data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id"/>
+            <td class="vuln-id hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.id</td>
+            <td class="vulnerable-component-name hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@splitVulnerableComponent.lift(1).getOrElse(summary.distinctVulnerability.vulnerableComponentName)</td>
+            <td class="assessment hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.assessment.getOrElse("")</td>
+            <td class="curation-status hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id"><div>@summary.distinctVulnerability.curationStatus.map(_.display).getOrElse("")</div></td>
+            <td class="score hand-pointer text-right" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id">@summary.distinctVulnerability.score.getOrElse("")</td>
+            <td class="services text-right hand-pointer" data-toggle="collapse" data-target="#collapsible-area-@summary.distinctVulnerability.id" aria-controls="collapsible-area-@summary.distinctVulnerability.id"><div>@summary.occurrences.groupBy(_.service).size</div></td>
+        </tr>
+        <tr id="collapsible-area-@summary.distinctVulnerability.id" class="collapse">
+            @*Provide hidden fields in collapsable element so that list.js sorting doesn't break when some rows are expanded*@
+            <td colspan="7">
+                <table>
+                    <tbody class="list">
+                        <tr>
+                            <td class="hide vuln-id">@summary.distinctVulnerability.id</td>
+                            <td class="hide vulnerable-component-name">@splitVulnerableComponent.lift(1).getOrElse(summary.distinctVulnerability.vulnerableComponentName)</td>
+                            <td class="hide assessment">@summary.distinctVulnerability.assessment.getOrElse("")</td>
+                            <td class="curation-status text-center hide"><div>@summary.distinctVulnerability.curationStatus.map(_.display).getOrElse("")</div></td>
+                            <td class="hide score text-center">@summary.distinctVulnerability.score.getOrElse("")</td>
+                            <td class="services text-center hide"><div>@summary.occurrences.groupBy(_.service).size</div></td>
+                        </tr>
+                        <tr>
+                            <td colspan="6">
+                                @VulnerabilityDetails(summary, splitVulnerableComponent.lift(0))
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+    }
 }
 
 <script @CSPNonce.attr>

--- a/app/views/vulnerabilities/VulnerabilityDetails.scala.html
+++ b/app/views/vulnerabilities/VulnerabilityDetails.scala.html
@@ -25,7 +25,7 @@
 @import uk.gov.hmrc.cataloguefrontend.model.SlugInfoFlag
 @import uk.gov.hmrc.cataloguefrontend.connector.model.DependencyScope
 @import uk.gov.hmrc.cataloguefrontend.connector.model.BobbyVersionRange
-@(vuln: VulnerabilitySummary)
+@(vuln: VulnerabilitySummary, dependencyType: Option[String])
 <div class="row">
     <div class="col-xs-12">
         <ul class="list list--minimal list-group row">
@@ -41,6 +41,12 @@
                 @fmt.format(Date.from(vuln.distinctVulnerability.publishedDate))
                 }
             </li>
+            @dependencyType.map{ dt =>
+                <li class="col-xs-6">
+                    <label>Dependency Type: </label>
+                     @dt
+                </li>
+            }
             <li class="col-xs-6">
                 <label>Vulnerable components on platform: </label>
                 <div style="height: 140px; overflow-y: auto; overflow-x: hidden">


### PR DESCRIPTION
…l view, and display it as separate nested field

Chose to lift the value from the list rather than directly accessing the index, just in case we see outliers which don't follow the expected pattern in the future - meaning we can fallback to the old behaviour rather than displaying an error.