### PR TITLE
BDOG-2660: Add sticky column to catalogue pages

### DIFF
--- a/app/views/BobbyExplorerPage.scala.html
+++ b/app/views/BobbyExplorerPage.scala.html
@@ -47,7 +47,7 @@
 @bobbyRulesArtifactTypeSection(rulesByArtifactType: Seq[BobbyRule], artifactType: String, inclViewSlugsLink: Boolean) = {
     @if(rulesByArtifactType.nonEmpty) {
         <div>
-            <table class="@{artifactType.toLowerCase}-rules table table-striped">
+            <table class="@{artifactType.toLowerCase}-rules table table-striped sticky-header">
                 <thead>
 
                     <tr>

--- a/app/views/DependencyExplorerPage.scala.html
+++ b/app/views/DependencyExplorerPage.scala.html
@@ -140,16 +140,20 @@
                 <table id="search-results" class="table table-striped">
                     <thead>
                         <tr>
-                            <th rowspan="2"><button class="sort no-border" data-sort="service">Service</button></th>
-                            <th rowspan="2">Version</th>
-                            <th rowspan="2"><button class="sort no-border" data-sort="teams">Team</button></th>
-                            <th colspan="4" class="text-center">Dependency</th>
-                        </tr>
-                        <tr>
-                            <th>Group ID</th>
-                            <th>Artefact ID</th>
-                            <th><button class="sort no-border" data-sort="dep-version">Version</button></th>
-                            <th>Scope</th>
+                            <th rowspan="2" class="wrw-table-head"><button class="sort no-border" data-sort="service">Service</button></th>
+                            <th rowspan="2" class="wrw-table-head">Version</th>
+                            <th rowspan="2" class="wrw-table-head"><button class="sort no-border" data-sort="teams">Team</button></th>
+                            <th colspan="2" class="wrw-table-head">
+                                <div class="text-center table-header-title">@{s"${searchResults.head.depGroup}.${searchResults.head.depArtefact}"}</div>
+                                <div class="row">
+                                    <div class="col-md-4">
+                                        <button class="sort no-border" data-sort="dep-version">Version</button>
+                                    </div>
+                                    <div class="col-md-6">
+                                        Scope
+                                    </div>
+                                </div>
+                            </th>
                         </tr>
                     </thead>
                     <tbody class="list">
@@ -160,8 +164,6 @@
                                 <td class="teams">
                                     @teamNames(result.teams, s"${uk.gov.hmrc.cataloguefrontend.routes.CatalogueController.service(result.slugName)}#teams")
                                 </td>
-                                <td>@result.depGroup</td>
-                                <td>@result.depArtefact</td>
                                 <td class="dep-version">@result.depVersion</td>
                                 <td>@result.scopes.map(_.displayString).mkString(", ")</td>
                             </tr>

--- a/app/views/DeploymentHistoryPage.scala.html
+++ b/app/views/DeploymentHistoryPage.scala.html
@@ -83,7 +83,7 @@
             </ul>
         </div>
 
-        <table class="table table-striped">
+        <table class="table table-striped sticky-header">
             <thead>
                 @pageNavigation()
                 <tr>

--- a/app/views/HealthIndicatorsLeaderBoard.scala.html
+++ b/app/views/HealthIndicatorsLeaderBoard.scala.html
@@ -60,7 +60,7 @@
                 </div>
             </div>
         </form>
-        <table class="table table-striped" id="health-indicators-leaderboard">
+        <table class="table table-striped sticky-header" id="health-indicators-leaderboard">
 
             <thead>
                 <th>Repository</th>

--- a/app/views/RepositoriesListPage.scala.html
+++ b/app/views/RepositoriesListPage.scala.html
@@ -85,7 +85,7 @@
             </div>
         </form>
 
-        <table class="table table-striped">
+        <table class="table table-striped sticky-header">
             <thead id="repo-table-headings">
                 <tr>
                     <th class="col-lg-3"><button role="button" id="name" data-sort="repo-name" class="sort no-border">Name</button></th>

--- a/app/views/leakdetection/LeakDetectionDraftPage.scala.html
+++ b/app/views/leakdetection/LeakDetectionDraftPage.scala.html
@@ -60,7 +60,7 @@
     }
 
     <div id="repo-list">
-        <table class="table table-striped">
+        <table class="table table-striped sticky-header">
             <thead>
                 <tr>
                     <th class="col-xs-7"><button class="sort no-border" data-sort="repository">Repository</button></th>

--- a/app/views/leakdetection/LeakDetectionExemptionsPage.scala.html
+++ b/app/views/leakdetection/LeakDetectionExemptionsPage.scala.html
@@ -50,7 +50,7 @@
     @if(unusedExemptions.nonEmpty) {
       <div id="unused-list">
         <h3>Unused Exemptions</h3>
-        <table class="table table-striped">
+        <table class="table table-striped sticky-header">
             <thead>
                 <tr>
                     <th class="col-xs-4"><button class="sort no-border" data-sort="rule">Rule</button></th>

--- a/app/views/leakdetection/LeakDetectionLeaksPage.scala.html
+++ b/app/views/leakdetection/LeakDetectionLeaksPage.scala.html
@@ -66,7 +66,7 @@
       <div class="col-xs-6">
       @if(exemptions.nonEmpty || report.unusedExemptions.nonEmpty) {
           <h3>Exemptions</h3>
-          <table class="table table-striped">
+          <table class="table table-striped sticky-header">
               <thead>
                   <tr>
                       <th class="col-xs-10">Rule</th>

--- a/app/views/leakdetection/LeakDetectionRepositoriesPage.scala.html
+++ b/app/views/leakdetection/LeakDetectionRepositoriesPage.scala.html
@@ -85,7 +85,7 @@
     </form>
 
     <div id="repo-list">
-        <table class="table table-striped">
+        <table class="table table-striped sticky-header">
             <thead>
                 <tr>
                     <th class="col-xs-5"><button class="sort no-border" data-sort="repository">Repository</button></th>

--- a/app/views/leakdetection/LeakDetectionRepositoryPage.scala.html
+++ b/app/views/leakdetection/LeakDetectionRepositoryPage.scala.html
@@ -51,7 +51,7 @@
         <div id="branch-list">
           <form id="rescan-form" method="POST">
             @csrfFormField
-            <table class="table table-striped">
+            <table class="table table-striped sticky-header">
                 <thead>
                     <tr>
                         <th class="col-xs-5"><button type="button" class="sort no-border" data-sort="branch">Branch</button></th>

--- a/app/views/prcommenter/PrCommenterRecommendationsPage.scala.html
+++ b/app/views/prcommenter/PrCommenterRecommendationsPage.scala.html
@@ -77,7 +77,7 @@
         <a id="expandLink" class="hand-pointer">expand all</a>
         <a id="collapseLink" class="hand-pointer hidden">collapse all</a>
       </div>
-      <table class="table table-striped">
+      <table class="table table-striped sticky-header">
         <thead>
           <tr>
             <th></th>

--- a/app/views/shuttering/ShutterOverviewPage.scala.html
+++ b/app/views/shuttering/ShutterOverviewPage.scala.html
@@ -65,7 +65,7 @@
     </p>
 
     <div id="service-list">
-        <table id="shutter-state-table" class="table table-striped">
+        <table id="shutter-state-table" class="table table-striped sticky-header">
             <thead>
               <tr>
                   <th id="service-header"><p class="shutter-overview-header"><button role="button" class="sort no-border" data-sort="shutter-service">Service</button></p></th>

--- a/app/views/teams/teams_list.scala.html
+++ b/app/views/teams/teams_list.scala.html
@@ -40,7 +40,7 @@
                 </div>
             </form>
 
-            <table class="table table-striped" id="service-list">
+            <table class="table table-striped sticky-header" id="service-list">
                 <thead>
                     <tr>
                         <th class="col-lg-7">

--- a/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
+++ b/app/views/vulnerabilities/VulnerabilitiesListPage.scala.html
@@ -77,7 +77,7 @@
         @if(summaries.isEmpty) {
             No results found matching the search criteria.
         } else {
-            <table style="word-break: break-word" class="table table-striped">
+            <table style="word-break: break-word" class="table table-striped sticky-header">
                 <thead>
                     <tr>
                         <th></th>

--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -3163,7 +3163,7 @@ tbody.collapse.in {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 1000;
+  z-index: 100000;
   display: none;
   float: left;
   min-width: 160px;
@@ -9015,7 +9015,7 @@ tbody.collapse.in {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 1000;
+  z-index: 100000;
   display: none;
   float: left;
   min-width: 160px;
@@ -12799,4 +12799,10 @@ table.sticky-header tbody tr.row-caption td {
 .input-group-inline dd {
   display: inline-block;
   margin-bottom: 0px;
+}
+
+th .table-header-title {
+  border-bottom: 2px solid #ddd;
+  padding: 8px 0;
+  margin: 8px 0;
 }


### PR DESCRIPTION
It's pretty much adding the `sticky-header` class from the config search changes, except for the change in `Dependency Explorer`.
https://jira.tools.tax.service.gov.uk/secure/attachment/568828/568828_sticky+column+dependency+explorer.webm
