### PR TITLE
BDOG-BAU fix google charts flickering on hover

### DIFF
--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -377,3 +377,7 @@ table.table-striped-columns-custom > :not(caption) > tr > td:nth-child(even) {
         display: none;
     }
 }
+
+/* Fixes a Google Charts flickering-on-over issue outlined here:
+   https://github.com/google/google-visualization-issues/issues/2162 */
+svg > g:last-child > g.google-visualization-tooltip { pointer-events: none }


### PR DESCRIPTION
This is a fix that was [previously implemented](https://github.com/hmrc/catalogue-frontend/pull/336/files), but got lost when we did the bootstrap 5 migration