### PR TITLE
BDOG-3885: Leak Detection - add back deleted CSS class

### DIFF
--- a/public/catalogue-frontend.css
+++ b/public/catalogue-frontend.css
@@ -441,3 +441,8 @@ svg > g:last-child > g.google-visualization-tooltip { pointer-events: none }
 .separator:not(:empty)::after {
     margin-left: .25em;
 }
+
+.highlighted {
+  background-color: #FFF3A3;
+  font-size: large;
+}


### PR DESCRIPTION
Added in https://github.com/hmrc/catalogue-frontend/pull/338 and removed in https://github.com/hmrc/catalogue-frontend/pull/672. I tweaked the colour slightly to something more standard for highlighting.

### Before
<img width="523" height="68" alt="image" src="https://github.com/user-attachments/assets/9dcc3fce-2e41-4f58-b797-1e50bfa1f8f5" />

### After
<img width="523" height="68" alt="image" src="https://github.com/user-attachments/assets/931b2450-34f2-4b8b-ba5c-4ff67dcc0b11" />
